### PR TITLE
Fixed TSLint 'prefer-for-of' and 'no-consecutive-blank-lines' warnings in MSBot

### DIFF
--- a/packages/MSBot/src/BotConfig.ts
+++ b/packages/MSBot/src/BotConfig.ts
@@ -226,8 +226,8 @@ export class BotConfig extends BotConfigModel {
     // encrypt just a service
     private encryptService(service: IConnectedService): IConnectedService {
         const encryptedProperties = this.getEncryptedProperties(<ServiceType>service.type);
-        for (let i = 0; i < encryptedProperties.length; i++) {
-            const prop = encryptedProperties[i];
+        for (const property of encryptedProperties) {
+            const prop = property;
             const val = <string>(<any>service)[prop];
             (<any>service)[prop] = this.encryptValue(val);
         }
@@ -237,8 +237,8 @@ export class BotConfig extends BotConfigModel {
     // decrypt just a service
     private decryptService(service: IConnectedService): IConnectedService {
         const encryptedProperties = this.getEncryptedProperties(<ServiceType>service.type);
-        for (let i = 0; i < encryptedProperties.length; i++) {
-            const prop = encryptedProperties[i];
+        for (const property of encryptedProperties) {
+            const prop = property;
             const val = <string>(<any>service)[prop];
             (<any>service)[prop] = this.decryptValue(val);
         }
@@ -259,4 +259,3 @@ export class BotConfig extends BotConfigModel {
         return value;
     }
 }
-

--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -55,4 +55,3 @@ export class BotConfigModel implements Partial<IBotConfig> {
         return { name, description, services, secretKey };
     }
 }
-


### PR DESCRIPTION
- Double blank lines in two different files were reduced to only one for fixing 'no-consecutive-blank-lines'.
- Two `for` structures were replaced with `for-of` structures as suggested by TSLint for fixing 'prefer-for-of' warnings in MSBot.