### PR TITLE
Fixed several TSLint `typedef` issues (part 3)

### DIFF
--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -22,7 +22,7 @@ program
     .arguments('<service_id_or_Name>')
     .description('disconnect a connected service by id or name')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
-    .action((idOrName, actions) => {
+    .action((idOrName: program.Command, actions: program.Command) => {
         actions.idOrName = idOrName;
     });
 

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -5,8 +5,9 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
+import { IConnectedService } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     showErrorHelp();
 };
@@ -25,7 +26,7 @@ program
         actions.idOrName = idOrName;
     });
 
-const args = <DisconnectServiceArgs><any>program.parse(process.argv);
+const args: DisconnectServiceArgs = <DisconnectServiceArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();
@@ -33,14 +34,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfig.LoadBotFromFolder(process.cwd())
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfig.Load(args.bot)
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -52,7 +53,7 @@ async function processConnectAzureArgs(config: BotConfig): Promise<BotConfig> {
         throw new Error('missing id or name of service to disconnect');
     }
 
-    const removedService = config.disconnectServiceByNameOrId(args.idOrName);
+    const removedService: IConnectedService = config.disconnectServiceByNameOrId(args.idOrName);
     if (removedService != null) {
         await config.save();
         process.stdout.write(`Disconnected ${removedService.type}:${removedService.name} ${removedService.id}`);
@@ -61,8 +62,8 @@ async function processConnectAzureArgs(config: BotConfig): Promise<BotConfig> {
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -5,7 +5,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -14,7 +14,7 @@ program
     .name('msbot export')
     .description('export all of the connected services to local files')
     .option('-bot, -b', 'path to bot file.  If omitted, local folder will look for a .bot file')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => {
     });
 program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -9,7 +9,7 @@ import * as readline from 'readline-sync';
 import { BotConfig } from './BotConfig';
 import { IEndpointService, ServiceType } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     program.help();
 };
@@ -41,7 +41,7 @@ const args: InitArgs = <InitArgs><any>program.parse(process.argv);
 
 if (!args.quiet) {
 
-    let exists = fsx.existsSync(`${args.name}.bot`);
+    let exists: boolean = fsx.existsSync(`${args.name}.bot`);
     while (((!args.hasOwnProperty('name') || args.name.length == 0)) || exists) {
         if (exists) {
             console.log(`${args.name}.bot already exists`);
@@ -51,7 +51,7 @@ if (!args.quiet) {
     }
 
     if (!args.secret || args.secret.length == 0) {
-        const answer = readline.question(`Would you to secure your bot keys with a secret? [no]`);
+        const answer: string = readline.question(`Would you to secure your bot keys with a secret? [no]`);
         if (answer == 'y' || answer == 'yes') {
             args.secret = readline.question(`What secret would you like to use? `);
         }
@@ -68,7 +68,7 @@ if (!args.quiet) {
     }
 
     if (!args.appId || args.appId.length == 0) {
-        const answer = readline.question(`Do you have an Application Id for this bot? [no] `, {
+        const answer: string = readline.question(`Do you have an Application Id for this bot? [no] `, {
             defaultInput: 'no'
         });
         if (answer == 'y' || answer == 'yes') {
@@ -88,7 +88,7 @@ if (!args.quiet) {
 if (!args.name) {
     console.error('missing --name argument');
 } else {
-    const bot = new BotConfig(args.secret);
+    const bot: BotConfig = new BotConfig(args.secret);
     bot.name = args.name;
     bot.description = args.description;
 
@@ -106,7 +106,7 @@ if (!args.name) {
         bot.validateSecretKey();
     }
 
-    const filename = bot.name + '.bot';
+    const filename: string = bot.name + '.bot';
     bot.save(filename);
     console.log(`${filename} created`);
 

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -33,7 +33,7 @@ program
     .option('-p, --appPassword <password>', 'Microsoft app password used for auth with the endpoint')
     .option('-e, --endpoint <endpoint>', 'local endpoint for the bot')
     .option('-q, --quiet', 'do not prompt')
-    .action((name, x) => {
+    .action((name: program.Command, x: program.Command) => {
         console.log(name);
     });
 

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -22,7 +22,7 @@ program
     .name('msbot list')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => {
     });
 
 const parsed: ListArgs = <ListArgs><any>program.parse(process.argv);

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -6,9 +6,9 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 import { BotConfig } from './BotConfig';
-import { IBotConfig } from './schema';
+import { IBotConfig, IConnectedService } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     showErrorHelp();
 };
@@ -25,26 +25,26 @@ program
     .action((cmd, actions) => {
     });
 
-const parsed = <ListArgs><any>program.parse(process.argv);
+const parsed: ListArgs = <ListArgs><any>program.parse(process.argv);
 
 if (!parsed.bot) {
     BotConfig.LoadBotFromFolder(process.cwd(), parsed.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 } else {
     BotConfig.Load(parsed.bot, parsed.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 }
 
 async function processListArgs(config: BotConfig): Promise<BotConfig> {
-    const services = config.services;
+    const services: IConnectedService[] = config.services;
 
     console.log(JSON.stringify(<IBotConfig>{
         name: config.name,
@@ -54,8 +54,8 @@ async function processListArgs(config: BotConfig): Promise<BotConfig> {
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -23,7 +23,7 @@ program
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'secret used to encrypt service keys')
     .option('-c, --clear', 'clear the secret and store keys unencrypted')
-    .action((name, x) => {
+    .action((name: program.Command, x: program.Command) => {
         console.log(name);
     });
 

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -6,7 +6,7 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
@@ -36,14 +36,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfig.LoadBotFromFolder(process.cwd(), args.secret)
             .then(processSecret)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfig.Load(args.bot, args.secret)
             .then(processSecret)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -60,8 +60,8 @@ async function processSecret(config: BotConfig): Promise<BotConfig> {
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -7,9 +7,9 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 
-const pkg = require('../package.json');
+const pkg: IPackage = require('../package.json');
 const semver = require('semver');
-const requiredVersion = pkg.engines.node;
+const requiredVersion: string = pkg.engines.node;
 if (!semver.satisfies(process.version, requiredVersion)) {
     console.error(`Required node version ${requiredVersion} not satisfied with current version ${process.version}.`);
     process.exit(1);
@@ -60,4 +60,9 @@ if (args) {
         return '';
     });
     process.exit(1);
+}
+
+interface IPackage {
+    engines: {node: string };
+    version: string;
 }

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -15,9 +15,9 @@ if (!semver.satisfies(process.version, requiredVersion)) {
     process.exit(1);
 }
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
-    program.outputHelp((str) => {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });
@@ -49,13 +49,13 @@ program
 program
     .command('list', 'list all connected services');
 
-const args = program.parse(process.argv);
+const args: program.Command = program.parse(process.argv);
 
 // args should be undefined is subcommand is executed
 if (args) {
-    const a = process.argv.slice(2);
+    const a: string[] = process.argv.slice(2);
     console.error(chalk.default.redBright(`Unknown arguments: ${a.join(' ')}`));
-    program.outputHelp((str) => {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });


### PR DESCRIPTION
Several TSLint 'typedef' warnings were solved in the following files in MSBot path:
- msbot-disconnect.ts
- msbot-export.ts
- msbot-init.ts
- msbot-list.ts
- msbot-secret.ts
- msbot.ts

Also, a new Interface was [added ](https://github.com/southworkscom/botbuilder-tools/pull/9/files#diff-e6fa6771e47f7d66c2f9a145152b480cR65) to model the `package.json` imported in `msbot.js`