### PR TITLE
TSLint warnings for `no-console` were disabled in some files

### DIFF
--- a/packages/MSBot/src/msbot-clone.ts
+++ b/packages/MSBot/src/msbot-clone.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';
 import * as getStdin from 'get-stdin';

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';
 import * as getStdin from 'get-stdin';

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -2,14 +2,15 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';
 import { BotConfig } from './BotConfig';
 import { FileService } from './models/fileService';
 import { IFileService, ServiceType } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     showErrorHelp();
 };
@@ -30,7 +31,7 @@ program
         }
     });
 
-const args = <ConnectFileArgs><any>program.parse(process.argv);
+const args: ConnectFileArgs = <ConnectFileArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();
@@ -38,14 +39,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfig.LoadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectFile)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfig.Load(args.bot, args.secret)
             .then(processConnectFile)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -60,7 +61,7 @@ async function processConnectFile(config: BotConfig): Promise<BotConfig> {
     }
 
     // add the service
-    const newService = new FileService({
+    const newService: FileService = new FileService({
         id: args.filePath,
         name: path.basename(args.filePath),
         filePath: args.filePath
@@ -71,8 +72,8 @@ async function processConnectFile(config: BotConfig): Promise<BotConfig> {
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';
 import * as getStdin from 'get-stdin';
@@ -12,7 +13,7 @@ import { LuisService } from './models';
 import { ILuisService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     showErrorHelp();
 };
@@ -41,7 +42,7 @@ program
 
     });
 
-const args = <ConnectLuisArgs><any>program.parse(process.argv);
+const args: ConnectLuisArgs = <ConnectLuisArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();
@@ -49,14 +50,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfig.LoadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectLuisArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfig.Load(args.bot, args.secret)
             .then(processConnectLuisArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -97,15 +98,15 @@ async function processConnectLuisArgs(config: BotConfig): Promise<BotConfig> {
     //    throw new Error("bad or missing --subscriptionKey");
 
     // add the service
-    const newService = new LuisService(args);
+    const newService: LuisService = new LuisService(args);
     config.connectService(newService);
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';
 import * as getStdin from 'get-stdin';
@@ -13,7 +14,7 @@ import { QnaMakerService } from './models';
 import { IQnAService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (flag: any): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
     showErrorHelp();
 };
@@ -44,7 +45,7 @@ program
 
 program.parse(process.argv);
 
-const args = <ConnectQnaArgs><any>program.parse(process.argv);
+const args: ConnectQnaArgs = <ConnectQnaArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();
@@ -52,14 +53,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfig.LoadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectQnaArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfig.Load(args.bot, args.secret)
             .then(processConnectQnaArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -96,7 +97,7 @@ async function processConnectQnaArgs(config: BotConfig): Promise<BotConfig> {
     }
 
     // add the service
-    const newService = new QnaMakerService(args);
+    const newService: QnaMakerService = new QnaMakerService(args);
     config.connectService(newService);
 
     await config.save();
@@ -104,8 +105,8 @@ async function processConnectQnaArgs(config: BotConfig): Promise<BotConfig> {
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
         return '';
     });

--- a/packages/MSBot/src/msbot-connect.ts
+++ b/packages/MSBot/src/msbot-connect.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 
 program.Command.prototype.unknownOption = function (flag: any) {

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
 

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 
 program.Command.prototype.unknownOption = function (flag: any) {

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fsx from 'fs-extra';
 import * as readline from 'readline-sync';

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 import { BotConfig } from './BotConfig';

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -2,7 +2,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
 

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -3,7 +3,8 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import * as chalk from 'chalk';
+// tslint:disable:no-console
+ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 


### PR DESCRIPTION
The 'no-console' rule was disabled in some files located in `MSBot\src\`. These files correspond to a console functionality , so the commands `console.error` are needed.