### PR TITLE
Fixed several TSLint 'typedef' issues in `/models`

### DIFF
--- a/packages/MSBot/src/models/azureBotService.ts
+++ b/packages/MSBot/src/models/azureBotService.ts
@@ -6,10 +6,10 @@ import { IAzureBotService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class AzureBotService extends ConnectedService implements IAzureBotService {
-    public readonly type = ServiceType.AzureBotService;
-    public tenantId = '';
-    public subscriptionId = '';
-    public resourceGroup = '';
+    public readonly type: ServiceType = ServiceType.AzureBotService;
+    public tenantId: string = '';
+    public subscriptionId: string = '';
+    public resourceGroup: string = '';
 
     constructor(source: IAzureBotService = {} as IAzureBotService) {
         super(source);

--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -15,7 +15,7 @@ export class BotConfigModel implements Partial<IBotConfig> {
     public name: string = '';
     public description: string = '';
     public services: IConnectedService[] = [];
-    public secretKey = '';
+    public secretKey: string = '';
 
     public static serviceFromJSON(service: IConnectedService): ConnectedService {
         switch (service.type) {
@@ -45,7 +45,7 @@ export class BotConfigModel implements Partial<IBotConfig> {
     public static fromJSON(source: Partial<IBotConfig> = {}): BotConfigModel {
         let { name = '', description = '', secretKey = '', services = [] } = source;
         services = services.slice().map(BotConfigModel.serviceFromJSON);
-        const botConfig = new BotConfigModel();
+        const botConfig: BotConfigModel = new BotConfigModel();
         Object.assign(botConfig, { services, description, name, secretKey });
         return botConfig;
     }
@@ -55,4 +55,4 @@ export class BotConfigModel implements Partial<IBotConfig> {
         return { name, description, services, secretKey };
     }
 }
-
+

--- a/packages/MSBot/src/models/connectedService.ts
+++ b/packages/MSBot/src/models/connectedService.ts
@@ -5,8 +5,8 @@
 import { IConnectedService, ServiceType } from '../schema';
 
 export abstract class ConnectedService implements IConnectedService {
-    public id = '';
-    public name = '';
+    public id: string = '';
+    public name: string = '';
     public abstract readonly type: ServiceType;
 
     protected constructor(source: IConnectedService = {} as IConnectedService) {

--- a/packages/MSBot/src/models/dispatchService.ts
+++ b/packages/MSBot/src/models/dispatchService.ts
@@ -6,12 +6,12 @@ import { IDispatchService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class DispatchService extends ConnectedService implements IDispatchService {
-    public readonly type = ServiceType.Dispatch;
-    public appId = '';
-    public authoringKey = '';
+    public readonly type: ServiceType = ServiceType.Dispatch;
+    public appId: string = '';
+    public authoringKey: string = '';
     public serviceIds: string[] = [];
-    public subscriptionKey = '';
-    public version = '';
+    public subscriptionKey: string = '';
+    public version: string = '';
 
     constructor(source: IDispatchService = {} as IDispatchService) {
         super(source);

--- a/packages/MSBot/src/models/endpointService.ts
+++ b/packages/MSBot/src/models/endpointService.ts
@@ -6,11 +6,11 @@ import { IEndpointService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class EndpointService extends ConnectedService implements IEndpointService {
-    public readonly type = ServiceType.Endpoint;
+    public readonly type: ServiceType = ServiceType.Endpoint;
 
-    public appId = '';
-    public appPassword = '';
-    public endpoint = '';
+    public appId: string = '';
+    public appPassword: string = '';
+    public endpoint: string = '';
 
     constructor(source: IEndpointService) {
         super(source);

--- a/packages/MSBot/src/models/fileService.ts
+++ b/packages/MSBot/src/models/fileService.ts
@@ -6,8 +6,8 @@ import { IFileService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class FileService extends ConnectedService implements IFileService {
-    public readonly type = ServiceType.File;
-    public filePath = '';
+    public readonly type: ServiceType = ServiceType.File;
+    public filePath: string = '';
 
     constructor(source: IFileService = {} as IFileService) {
         super(source);

--- a/packages/MSBot/src/models/luisService.ts
+++ b/packages/MSBot/src/models/luisService.ts
@@ -6,11 +6,11 @@ import { ILuisService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class LuisService extends ConnectedService implements ILuisService {
-    public readonly type = ServiceType.Luis;
-    public appId = '';
-    public authoringKey = '';
-    public subscriptionKey = '';
-    public version = '';
+    public readonly type: ServiceType = ServiceType.Luis;
+    public appId: string = '';
+    public authoringKey: string = '';
+    public subscriptionKey: string = '';
+    public version: string = '';
 
     constructor(source: ILuisService = {} as ILuisService) {
         super(source);

--- a/packages/MSBot/src/models/qnaMakerService.ts
+++ b/packages/MSBot/src/models/qnaMakerService.ts
@@ -7,11 +7,11 @@ import { IQnAService, ServiceType } from '../schema';
 import { ConnectedService } from './connectedService';
 
 export class QnaMakerService extends ConnectedService implements IQnAService {
-    public readonly type = ServiceType.QnA;
-    public kbId = '';
-    public subscriptionKey = '';
-    public hostname = '';
-    public endpointKey = '';
+    public readonly type: ServiceType = ServiceType.QnA;
+    public kbId: string = '';
+    public subscriptionKey: string = '';
+    public hostname: string = '';
+    public endpointKey: string = '';
 
     constructor(source: IQnAService = {} as IQnAService) {
         super(source);


### PR DESCRIPTION
Several TSLint 'typedef' warnings were solved in the following files in `MSBot\src\models` path:
- azureBotService.ts
- botConfigModel.ts
- connectedService.ts
- dispatchService.ts
- endpointService.ts
- fileService.ts
- luisService.ts
- qnaMakerService.ts