### PR TITLE
Fixed TSLint warnings for `no-this-assignment` rule for the following files:

### DIFF
--- a/packages/MSBot/bin/models/qnaMakerService.js
+++ b/packages/MSBot/bin/models/qnaMakerService.js
@@ -23,7 +23,12 @@ class QnaMakerService extends connectedService_1.ConnectedService {
         Object.assign(this, { id, name, kbId, subscriptionKey, endpointKey, hostname });
     }
     toJSON() {
-        const { id, name, kbId, subscriptionKey, endpointKey, hostname } = this;
+        const id = this.id;
+        const name = this.name;
+        const kbId = this.kbId;
+        const subscriptionKey = this.subscriptionKey;
+        const endpointKey = this.endpointKey;
+        const hostname = this.hostname;
         return { type: schema_1.ServiceType.QnA, id: kbId, name, kbId, subscriptionKey, endpointKey, hostname };
     }
 }

--- a/packages/MSBot/src/models/azureBotService.ts
+++ b/packages/MSBot/src/models/azureBotService.ts
@@ -18,7 +18,12 @@ export class AzureBotService extends ConnectedService implements IAzureBotServic
     }
 
     public toJSON(): IAzureBotService {
-        const { id, name, tenantId, subscriptionId, resourceGroup } = this;
-        return { type: ServiceType.AzureBotService, id, name, tenantId, subscriptionId, resourceGroup };
+        return {
+            type: ServiceType.AzureBotService,
+            id: this.id,
+            name: this.name,
+            tenantId: this.tenantId,
+            subscriptionId: this.subscriptionId,
+            resourceGroup: this.resourceGroup};
     }
 }

--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -51,8 +51,10 @@ export class BotConfigModel implements Partial<IBotConfig> {
     }
 
     public toJSON(): Partial<IBotConfig> {
-        const { name, description, services, secretKey } = this;
-        return { name, description, services, secretKey };
+        return {
+            name: this.name,
+            description: this.description,
+            services: this.services,
+            secretKey: this.secretKey };
     }
 }
-

--- a/packages/MSBot/src/models/dispatchService.ts
+++ b/packages/MSBot/src/models/dispatchService.ts
@@ -21,7 +21,13 @@ export class DispatchService extends ConnectedService implements IDispatchServic
     }
 
     public toJSON(): IDispatchService {
-        const { appId, authoringKey, name, serviceIds, subscriptionKey, version } = this;
-        return {  type: ServiceType.Dispatch, id: appId, name, appId, authoringKey, serviceIds, subscriptionKey, version };
+        return {  type: ServiceType.Dispatch,
+            id: this.appId,
+            name: this.name,
+            appId: this.appId,
+            authoringKey: this.authoringKey,
+            serviceIds: this.serviceIds,
+            subscriptionKey: this.subscriptionKey,
+            version: this.version };
     }
 }

--- a/packages/MSBot/src/models/endpointService.ts
+++ b/packages/MSBot/src/models/endpointService.ts
@@ -20,7 +20,12 @@ export class EndpointService extends ConnectedService implements IEndpointServic
     }
 
     public toJSON(): IEndpointService {
-        const { appId = '', id = '', appPassword = '', endpoint = '', name = '' } = this;
-        return { type: ServiceType.Endpoint, name, id: endpoint, appId, appPassword, endpoint };
+        return {
+            type: ServiceType.Endpoint,
+            name: this.name,
+            id: this.endpoint,
+            appId: this.appId,
+            appPassword: this.appPassword,
+            endpoint: this.endpoint };
     }
 }

--- a/packages/MSBot/src/models/fileService.ts
+++ b/packages/MSBot/src/models/fileService.ts
@@ -17,7 +17,10 @@ export class FileService extends ConnectedService implements IFileService {
     }
 
     public toJSON(): IFileService {
-        const { name = '', id = '', filePath = '' } = this;
-        return { type: ServiceType.File, id: filePath, name, filePath };
+        return {
+            type: ServiceType.File,
+            id: this.filePath,
+            name: this.name,
+            filePath: this.filePath };
     }
 }

--- a/packages/MSBot/src/models/luisService.ts
+++ b/packages/MSBot/src/models/luisService.ts
@@ -20,7 +20,13 @@ export class LuisService extends ConnectedService implements ILuisService {
     }
 
     public toJSON(): ILuisService {
-        const { appId, authoringKey, id, name, subscriptionKey, type, version } = this;
-        return { type: ServiceType.Luis, id: appId, name, version, appId, authoringKey, subscriptionKey };
+        return {
+            type: ServiceType.Luis,
+            id: this.appId,
+            name: this.name,
+            version: this.version,
+            appId: this.appId,
+            authoringKey: this.authoringKey,
+            subscriptionKey: this.subscriptionKey };
     }
 }

--- a/packages/MSBot/src/models/qnaMakerService.ts
+++ b/packages/MSBot/src/models/qnaMakerService.ts
@@ -24,7 +24,13 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
     }
 
     public toJSON(): IQnAService {
-        const { id, name, kbId, subscriptionKey, endpointKey, hostname } = this;
+        const id: string = this.id;
+        const name: string = this.name;
+        const kbId: string = this.kbId;
+        const subscriptionKey:string = this.subscriptionKey;
+        const endpointKey: string = this.endpointKey;
+        const hostname: string = this.hostname;
+
         return { type: ServiceType.QnA, id: kbId, name, kbId, subscriptionKey, endpointKey, hostname };
     }
 }


### PR DESCRIPTION
- azureBotService.ts
- botConfigModel.ts
- dispatchService.ts
- endpointService.ts
- fileService.ts
- luisService.ts
- qnaMakerService.ts