### PR TITLE
Fixed TSLint `interface-name` warnings

### DIFF
--- a/packages/MSBot/src/BotConfig.ts
+++ b/packages/MSBot/src/BotConfig.ts
@@ -12,7 +12,7 @@ import * as uuid from 'uuid';
 import { BotConfigModel } from './models';
 import { IBotConfig, IConnectedService, IDispatchService, ServiceType } from './schema';
 
-interface internalBotConfig {
+interface IinternalBotConfig {
     location?: string;
     secret?: string;
     secretValidated: boolean;
@@ -28,7 +28,7 @@ export class BotConfig extends BotConfigModel {
         dispatch: ['authoringKey', 'subscriptionKey']
     };
     // internal is not serialized
-    private internal: internalBotConfig = {
+    private internal: IinternalBotConfig = {
         secretValidated: false
     };
 
@@ -259,4 +259,3 @@ export class BotConfig extends BotConfigModel {
         return value;
     }
 }
-

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -18,7 +18,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectAzureArgs extends IAzureBotService {
+interface IConnectAzureArgs extends IAzureBotService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -48,7 +48,7 @@ program
 
     });
 
-const args = <ConnectAzureArgs><any>program.parse(process.argv);
+const args = <IConnectAzureArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -18,7 +18,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectLuisArgs extends ILuisService {
+interface IConnectLuisArgs extends ILuisService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -42,7 +42,7 @@ program
 
     });
 
-const args = <ConnectLuisArgs><any>program.parse(process.argv);
+const args = <IConnectLuisArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -19,7 +19,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectEndpointArgs extends IEndpointService {
+interface IConnectEndpointArgs extends IEndpointService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -42,7 +42,7 @@ program
 
     });
 
-const args = <ConnectEndpointArgs><any>program.parse(process.argv);
+const args = <IConnectEndpointArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     showErrorHelp();

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -14,7 +14,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectFileArgs extends IFileService {
+interface IConnectFileArgs extends IFileService {
     bot: string;
     secret: string;
 }
@@ -30,7 +30,7 @@ program
         }
     });
 
-const args = <ConnectFileArgs><any>program.parse(process.argv);
+const args = <IConnectFileArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -17,7 +17,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectLuisArgs extends ILuisService {
+interface IConnectLuisArgs extends ILuisService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -41,7 +41,7 @@ program
 
     });
 
-const args = <ConnectLuisArgs><any>program.parse(process.argv);
+const args = <IConnectLuisArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -18,7 +18,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ConnectQnaArgs extends IQnAService {
+interface IConnectQnaArgs extends IQnAService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -44,7 +44,7 @@ program
 
 program.parse(process.argv);
 
-const args = <ConnectQnaArgs><any>program.parse(process.argv);
+const args = <IConnectQnaArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -11,7 +11,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface DisconnectServiceArgs {
+interface IDisconnectServiceArgs {
     bot: string;
     idOrName: string;
 }
@@ -25,7 +25,7 @@ program
         actions.idOrName = idOrName;
     });
 
-const args = <DisconnectServiceArgs><any>program.parse(process.argv);
+const args = <IDisconnectServiceArgs><any>program.parse(process.argv);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -13,7 +13,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface ListArgs {
+interface IListArgs {
     bot: string;
     secret: string;
 }
@@ -25,7 +25,7 @@ program
     .action((cmd, actions) => {
     });
 
-const parsed = <ListArgs><any>program.parse(process.argv);
+const parsed = <IListArgs><any>program.parse(process.argv);
 
 if (!parsed.bot) {
     BotConfig.LoadBotFromFolder(process.cwd(), parsed.secret)

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -11,7 +11,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     showErrorHelp();
 };
 
-interface SecretArgs {
+interface ISecretArgs {
     bot: string;
     secret: string;
     endpoint: string;
@@ -27,7 +27,7 @@ program
         console.log(name);
     });
 
-const args: SecretArgs = <SecretArgs><any>program.parse(process.argv);
+const args: ISecretArgs = <ISecretArgs><any>program.parse(process.argv);
 let path: string;
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
The interfaces of the following files were renamed:

- BotConfig.ts
- msbot-connect-azure.ts
- msbot-connect-dispatch.ts
- msbot-connect-endpoint.ts
- msbot-connect-file.ts
- msbot-connect-luis.ts
- msbot-connect-qna.ts
- msbot-disconnect.ts
- msbot-list.ts
- msbot-secret.ts