### PR TITLE
Fixed TSLint 'no-var-requires' warnings in MSBot

### DIFF
--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -37,6 +37,7 @@
     "@types/readline-sync": "^1.4.3",
     "@types/uuid": "^3.4.3",
     "@types/valid-url": "^1.0.2",
+    "@types/semver":"^5.5.0",
     "mocha": "^5.2.0"
   },
   "dependencies": {

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -6,9 +6,10 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
+import * as semver from 'semver';
 
+// tslint:disable-next-line:no-require-imports no-var-requires
 const pkg = require('../package.json');
-const semver = require('semver');
 const requiredVersion = pkg.engines.node;
 if (!semver.satisfies(process.version, requiredVersion)) {
     console.error(`Required node version ${requiredVersion} not satisfied with current version ${process.version}.`);


### PR DESCRIPTION
- Changed one `require` for one `import`, but had to add a new line to `devDependencies` of the `package.json` inside MSBot: 
`"@types/semver":"^5.5.0"`
- Added an exception for rules `no-require-imports` and `no-var-requires` in the line:
`const pkg = require('../package.json');`
This due to TS having troubles with importing JSON files.