### PR TITLE
Fixed TSLint 'prefer-template' and 'type-literal-delimiter' warnings in MSBot

### DIFF
--- a/packages/MSBot/src/BotConfig.ts
+++ b/packages/MSBot/src/BotConfig.ts
@@ -20,7 +20,7 @@ interface internalBotConfig {
 
 export class BotConfig extends BotConfigModel {
 
-    protected encryptedProperties: { [key: string]: string[]; } = {
+    protected encryptedProperties: { [key: string]: string[] } = {
         endpoint: ['appPassword'],
         abs: ['appPassword'],
         luis: ['authoringKey', 'subscriptionKey'],

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -106,7 +106,7 @@ if (!args.name) {
         bot.validateSecretKey();
     }
 
-    const filename = bot.name + '.bot';
+    const filename = `${bot.name}.bot`;
     bot.save(filename);
     console.log(`${filename} created`);
 


### PR DESCRIPTION
- Removed an extra semi colon in a file.
- Removed concatenating in a `string`, instead used `string template`.