### PR TITLE
Fixed several `no-type` warnings on multiple files

### DIFF
--- a/packages/MSBot/src/BotConfig.ts
+++ b/packages/MSBot/src/BotConfig.ts
@@ -228,8 +228,8 @@ export class BotConfig extends BotConfigModel {
         const encryptedProperties = this.getEncryptedProperties(<ServiceType>service.type);
         for (let i = 0; i < encryptedProperties.length; i++) {
             const prop = encryptedProperties[i];
-            const val = <string>(<any>service)[prop];
-            (<any>service)[prop] = this.encryptValue(val);
+            const val = <string>(<IConnectedService>service)[prop];
+            (<IConnectedService>service)[prop] = this.encryptValue(val);
         }
         return service;
     }
@@ -239,8 +239,8 @@ export class BotConfig extends BotConfigModel {
         const encryptedProperties = this.getEncryptedProperties(<ServiceType>service.type);
         for (let i = 0; i < encryptedProperties.length; i++) {
             const prop = encryptedProperties[i];
-            const val = <string>(<any>service)[prop];
-            (<any>service)[prop] = this.decryptValue(val);
+            const val = <string>(<IConnectedService>service)[prop];
+            (<IConnectedService>service)[prop] = this.decryptValue(val);
         }
         return service;
     }
@@ -259,4 +259,3 @@ export class BotConfig extends BotConfigModel {
         return value;
     }
 }
-

--- a/packages/MSBot/src/msbot-clone.ts
+++ b/packages/MSBot/src/msbot-clone.ts
@@ -5,7 +5,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -13,8 +13,8 @@ import { AzureBotService, EndpointService } from './models';
 import { IAzureBotService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -13,8 +13,8 @@ import { DispatchService } from './models';
 import { IConnectedService, IDispatchService, ILuisService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -14,8 +14,8 @@ import { EndpointService } from './models';
 import { IEndpointService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -9,8 +9,8 @@ import { BotConfig } from './BotConfig';
 import { FileService } from './models/fileService';
 import { IFileService, ServiceType } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -12,8 +12,8 @@ import { LuisService } from './models';
 import { ILuisService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -13,8 +13,8 @@ import { QnaMakerService } from './models';
 import { IQnAService, ServiceType } from './schema';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-connect.ts
+++ b/packages/MSBot/src/msbot-connect.ts
@@ -5,7 +5,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -6,8 +6,8 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -5,7 +5,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -9,8 +9,8 @@ import * as readline from 'readline-sync';
 import { BotConfig } from './BotConfig';
 import { IEndpointService, ServiceType } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };
 

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -8,8 +8,8 @@ import * as process from 'process';
 import { BotConfig } from './BotConfig';
 import { IBotConfig } from './schema';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -6,7 +6,7 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -15,7 +15,7 @@ if (!semver.satisfies(process.version, requiredVersion)) {
     process.exit(1);
 }
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.outputHelp((str) => {
         console.error(str);

--- a/packages/MSBot/src/schema.ts
+++ b/packages/MSBot/src/schema.ts
@@ -20,6 +20,9 @@ export interface IConnectedService {
 
     // unique Id for the service (appid, etc)
     id?: string;
+
+    // tslint:disable-next-line:no-any
+    [key: string]: any;
 }
 
 export interface IEndpointService extends IConnectedService {


### PR DESCRIPTION
### Schema.ts
- Added `key` property of type `any`. This allows the casting of type in file `BotConfig.ts`
- Added exception to the rule

### BotConfig.ts
- By adding the key in `schema.ts` it was possible to cast the interface

### All `msbot*` files had the following modifications
- Removed unused variable `flag`
- Modified function to use arrow type function
- Added function type definition

### Additionally the an additional modification of replacing `flag` with `process.argv` was made in the following files:
- msbot-connect-azure.ts
- msbot-connect-dispatch.ts
- msbot-connect-endpoint.ts
- msbot-connect-luis.ts
- msbot-connect-file.ts
- msbot-connect-qna.ts
- msbot-connect-disconnect.ts
- msbot-init.ts
- msbot-list.ts

