### PR TITLE
Fixed several `no-any` TSLint warnings

### DIFF
--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -48,7 +48,23 @@ program
 
     });
 
-const args = <ConnectAzureArgs><any>program.parse(process.argv);
+const args: ConnectAzureArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    tenantId: '',
+    subscriptionId: '',
+    resourceGroup: '',
+    type: ServiceType.AzureBotService,
+    name: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -55,11 +55,9 @@ const args: ConnectLuisArgs = {
 };
 
 const commands: program.Command = program.parse(process.argv);
-for (const i of commands.args) {
-    if (args.hasOwnProperty(i)) {
-        args[i] = commands[i];
-    }
-}
+Object.keys(args).forEach(key => {
+    args[key] = commands[key];
+});
 
 if (process.argv.length < 3) {
     program.help();
@@ -124,14 +122,11 @@ async function processConnectDispatch(config: BotConfig): Promise<BotConfig> {
         name: ''
     };
 
-    for (const i of commands.args) {
-        if (dispatchService.hasOwnProperty(i)) {
-            dispatchService[i] = args[i];
-        }
-    }
+    Object.keys(dispatchService).forEach(key => {
+        dispatchService[key] = args[key];
+    });
 
     const newService = new DispatchService(dispatchService);
-
     const dispatchServices = <IConnectedService[]>(args).services;
 
     if (<IConnectedService[]>dispatchServices) {

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -42,7 +42,24 @@ program
 
     });
 
-const args = <ConnectLuisArgs><any>program.parse(process.argv);
+const args: ConnectLuisArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    appId: '',
+    authoringKey: '',
+    subscriptionKey: '',
+    version: '',
+    name: '',
+    type: ServiceType.Dispatch
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();
@@ -97,9 +114,25 @@ async function processConnectDispatch(config: BotConfig): Promise<BotConfig> {
         args.id = args.appId;
     }
 
-    const newService = new DispatchService(<IDispatchService><any>args);
+    const dispatchService: IDispatchService = {
+        appId: '',
+        authoringKey: '',
+        subscriptionKey: '',
+        version: '',
+        serviceIds: [''],
+        type: ServiceType.Dispatch,
+        name: ''
+    };
 
-    const dispatchServices = <IConnectedService[]>(<any>args).services;
+    for (const i of commands.args) {
+        if (dispatchService.hasOwnProperty(i)) {
+            dispatchService[i] = args[i];
+        }
+    }
+
+    const newService = new DispatchService(dispatchService);
+
+    const dispatchServices = <IConnectedService[]>(args).services;
 
     if (<IConnectedService[]>dispatchServices) {
         for (const service of dispatchServices) {

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -42,7 +42,26 @@ program
 
     });
 
-const args = <ConnectEndpointArgs><any>program.parse(process.argv);
+const args: ConnectEndpointArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    appId: '',
+    appPassword: '',
+    tenantId: '',
+    subscriptionId: '',
+    resourceGroup: '',
+    type: ServiceType.AzureBotService,
+    name: '',
+    endpoint: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     showErrorHelp();

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -30,7 +30,20 @@ program
         }
     });
 
-const args = <ConnectFileArgs><any>program.parse(process.argv);
+const args: ConnectFileArgs = {
+    bot: '',
+    secret: '',
+    type: ServiceType.File,
+    name: '',
+    filePath: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -41,7 +41,24 @@ program
 
     });
 
-const args = <ConnectLuisArgs><any>program.parse(process.argv);
+const args: ConnectLuisArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    appId: '',
+    authoringKey: '',
+    subscriptionKey: '',
+    version: '',
+    type: ServiceType.Luis,
+    name: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -44,7 +44,25 @@ program
 
 program.parse(process.argv);
 
-const args = <ConnectQnaArgs><any>program.parse(process.argv);
+const args: ConnectQnaArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    subscriptionId: '',
+    subscriptionKey: '',
+    kbId: '',
+    hostname: '',
+    endpointKey: '',
+    type: ServiceType.QnA,
+    name: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -14,6 +14,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
 interface DisconnectServiceArgs {
     bot: string;
     idOrName: string;
+    [key: string]: string;
 }
 
 program
@@ -25,7 +26,17 @@ program
         actions.idOrName = idOrName;
     });
 
-const args = <DisconnectServiceArgs><any>program.parse(process.argv);
+const args: DisconnectServiceArgs = {
+    bot: '',
+    idOrName: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -22,6 +22,7 @@ interface InitArgs {
     appId: string;
     appPassword: string;
     quiet: boolean;
+    [key: string]: string | boolean;
 }
 
 program
@@ -37,7 +38,22 @@ program
         console.log(name);
     });
 
-const args: InitArgs = <InitArgs><any>program.parse(process.argv);
+const args: InitArgs = {
+    name: '',
+    description: '',
+    secret: '',
+    endpoint: '',
+    appId: '',
+    appPassword: '',
+    quiet: false
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (!args.quiet) {
 

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -16,6 +16,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
 interface ListArgs {
     bot: string;
     secret: string;
+    [key: string]: string;
 }
 
 program
@@ -25,17 +26,27 @@ program
     .action((cmd, actions) => {
     });
 
-const parsed = <ListArgs><any>program.parse(process.argv);
+const args: ListArgs = {
+    bot: '',
+    secret: ''
+};
 
-if (!parsed.bot) {
-    BotConfig.LoadBotFromFolder(process.cwd(), parsed.secret)
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
+
+if (!args.bot) {
+    BotConfig.LoadBotFromFolder(process.cwd(), args.secret)
         .then(processListArgs)
         .catch((reason) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 } else {
-    BotConfig.Load(parsed.bot, parsed.secret)
+    BotConfig.Load(args.bot, args.secret)
         .then(processListArgs)
         .catch((reason) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -16,6 +16,7 @@ interface SecretArgs {
     secret: string;
     endpoint: string;
     clear: boolean;
+    [key: string]: string | boolean;
 }
 
 program
@@ -27,7 +28,19 @@ program
         console.log(name);
     });
 
-const args: SecretArgs = <SecretArgs><any>program.parse(process.argv);
+const args: SecretArgs = {
+    bot: '',
+    secret: '',
+    endpoint: '',
+    clear: false
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 let path: string;
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
An structure was added for which then its property are filled by looping through the arguments inside of `commands.args`

It was also needed to add a key to the local interfaces of the following files:
- msbot-disconnect.ts
- msbot-init.ts
- msbot-list.ts
- msbot-secret.ts

Additionally, the variable `parse` in msbot-list.ts was renamed to `args` to keep naming consistency in all the files.