### PR TITLE
Fixed `switch-default` TSLint warning

### DIFF
--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -105,11 +105,8 @@ async function processConnectDispatch(config: BotConfig): Promise<BotConfig> {
         for (const service of dispatchServices) {
             newService.serviceIds.push(service.id || '');
             if (!Enumerable.fromSource(config.services).any(s => s.id == service.id)) {
-                switch (service.type) {
-                    case ServiceType.File:
-                    case ServiceType.Luis:
-                    case ServiceType.QnA:
-                        config.connectService(service);
+                if (service.type === ServiceType.File || service.type === ServiceType.Luis || service.type === ServiceType.QnA) {
+                    config.connectService(service);
                 }
             }
         }


### PR DESCRIPTION
A TSLint warning for the rul `switch-default` for the file was being raised on the file `msbot-connect-dispatch.ts`. Said rule explicitly says that 'switch cases' must include a default case. It was opted to use an `if` instead.