### PR TITLE
Fix TSLint warnings in msbot-export.ts

### DIFF
--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -6,7 +6,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };
@@ -15,7 +15,7 @@ program
     .name('msbot export')
     .description('export all of the connected services to local files')
     .option('-bot, -b', 'path to bot file.  If omitted, local folder will look for a .bot file')
-    .action((cmd, actions) => undefined);
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 program.parse(process.argv);
 
 console.error('not implemented yet');


### PR DESCRIPTION
Fix the following warnings in the file `msbot-export.ts`:
- `typedef`
- `no-any`