### PR TITLE
Fix TSLint warnings in msbot-list.ts

### DIFF
--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -3,58 +3,68 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration } from 'botframework-config';
+import { BotConfiguration, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ListArgs {
+interface IListArgs {
     bot: string;
     secret: string;
+    [key: string]: string;
 }
 
 program
     .name('msbot list')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
-    .action((cmd, actions) => {
-    });
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-let parsed = <ListArgs><any>program.parse(process.argv);
+const args: IListArgs = {
+    bot: '',
+    secret: ''
+};
 
-if (!parsed.bot) {
-    BotConfiguration.loadBotFromFolder(process.cwd(), parsed.secret)
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
+
+if (!args.bot) {
+    BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 } else {
-    BotConfiguration.load(parsed.bot, parsed.secret)
+    BotConfiguration.load(args.bot, args.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 }
 
-
 async function processListArgs(config: BotConfiguration): Promise<BotConfiguration> {
-    let services = config.services;
+    const services: IConnectedService[] = config.services;
 
     console.log(JSON.stringify(config, null, 4));
+
     return config;
 }
 
-function showErrorHelp()
-{
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);


### PR DESCRIPTION
## Proposed Changes
Fix the following warnings in the file `msbot-list.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `no-empty`
- `prefer-const`
- `no-consecutive-blank-lines`
- `newline-before-return`
- `one-line`

## Testing
Travis will no longer report this issue.