### PR TITLE
Fix TSLint warnings in msbot-disconnect.ts

### DIFF
--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -35,11 +35,7 @@ const args: IDisconnectServiceArgs = {
     secret: ''
 };
 const commands: program.Command = program.parse(process.argv);
-for (const i of commands.args) {
-    if (args.hasOwnProperty(i)) {
-        args[i] = commands[i];
-    }
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();


### PR DESCRIPTION
## Proposed Changes
Fix the following warnings in the file `msbot-disconnect.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `prefer-const`
- `no-consecutive-blank-lines`
- `newline-before-return`
- `eofline`

## Testing
Travis will no longer report this issue.