### PR TITLE
Fix TSLint issues in msbot-connect-file.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -16,8 +16,6 @@ program.Command.prototype.unknownOption = function (): void {
 interface IConnectFileArgs extends IFileService {
     bot: string;
     secret: string;
-    // tslint:disable-next-line:no-any
-    [key: string]: any;
 }
 
 program
@@ -38,9 +36,7 @@ const args: IConnectFileArgs = {
     name: ''
 };
 
-for (const key of args.keys) {
-    args[key] = commands[key];
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -8,14 +8,16 @@ import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = function (): void {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectFileArgs extends IFileService {
+interface IConnectFileArgs extends IFileService {
     bot: string;
     secret: string;
+    // tslint:disable-next-line:no-any
+    [key: string]: any;
 }
 
 program
@@ -23,12 +25,22 @@ program
     .description('Connect a file to the bot')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
-    .action((filePath, actions) => {
-        if (filePath)
-            actions.filePath = filePath;
+    .action((filePath: program.Command, actions: program.Command) => {
+        if (filePath) {
+            actions.filePath = filePath; }
     });
 
-let args = <ConnectFileArgs><any>program.parse(process.argv);
+const commands: program.Command = program.parse(process.argv);
+const args: IConnectFileArgs = {
+    bot: '',
+    secret: '',
+    path: '',
+    name: ''
+};
+
+for (const key of args.keys) {
+    args[key] = commands[key];
+}
 
 if (process.argv.length < 3) {
     program.help();
@@ -36,14 +48,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectFile)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectFile)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -53,24 +65,26 @@ if (process.argv.length < 3) {
 async function processConnectFile(config: BotConfiguration): Promise<BotConfiguration> {
     args.name = args.hasOwnProperty('name') ? args.name : config.name;
 
-    if (!args.hasOwnProperty('filePath'))
-        throw new Error('Bad or missing file');
+    if (!args.hasOwnProperty('filePath')) {
+        throw new Error('Bad or missing file'); }
 
-    // add the service
-    let newService = new FileService({
+    const connectedService: IFileService = {
         name: path.basename(args.path),
         path: args.path
-    } as IFileService);
-    let id = config.connectService(newService);
+    };
+    const newService: FileService = new FileService(connectedService);
+
+    const id: string = config.connectService(newService);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp()
-{
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);


### PR DESCRIPTION
## Proposed Changes
The following TSLint issues has been fixed in `msbot-connect-file.ts`:
- typedef
- no-any
- interface-name
- curly
- prefer-const
- no-object-literal-type-assertion-
- newline-before-return
- one-line
- eofline

A key had to be added to `IConnectFileArgs` to be able to iterate through its properties. The type of the key had to be `any` because otherwise it needed to be `undefined` which caused a `Object is possibly 'undefined'.` error in the loop logic.
## Testing
Travis will no longer report this issue.