### PR TITLE
Fix TSLint warnings in msbot-connect-cosmosdb.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -10,16 +10,17 @@ import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectoCosmosDbArgs extends ICosmosDBService {
+interface IConnectoCosmosDbArgs extends ICosmosDBService {
     bot: string;
     secret: string;
     stdin: boolean;
     input?: string;
+    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -31,18 +32,35 @@ program
     .option('-r, --resourceGroup <resourceGroup>', 'Azure resource group name')
     .option('--serviceName <serviceName>', 'Azure service name')
     .option('--connectionString <connectionString>', 'CosmosDB connection string')
-    .option('-d, --database <database>', "database name")
-    .option('-c, --collection <collection>', "collection name")
+    .option('-d, --database <database>', 'database name')
+    .option('-c, --collection <collection>', 'collection name')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-    });
+const args: IConnectoCosmosDbArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    connectionString: '',
+    database: '',
+    collection: '',
+    tenantId: '',
+    subscriptionId: '',
+    resourceGroup: '',
+    serviceName: '',
+    name: ''
+};
 
-let args = <ConnectoCosmosDbArgs><any>program.parse(process.argv);
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();
@@ -50,14 +68,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -67,33 +85,39 @@ if (process.argv.length < 3) {
 async function processConnectAzureArgs(config: BotConfiguration): Promise<BotConfiguration> {
     if (args.stdin) {
         Object.assign(args, JSON.parse(await getStdin()));
-    }
-    else if (args.input != null) {
+    } else if (args.input != null) {
         Object.assign(args, JSON.parse(await txtfile.read(<string>args.input)));
     }
 
-    if (!args.serviceName || args.serviceName.length == 0)
+    if (!args.serviceName || args.serviceName.length === 0) {
         throw new Error('Bad or missing --serviceName');
+        }
 
-    if (!args.tenantId || args.tenantId.length == 0)
+    if (!args.tenantId || args.tenantId.length === 0) {
         throw new Error('Bad or missing --tenantId');
+        }
 
-    if (!args.subscriptionId || !uuidValidate(args.subscriptionId))
+    if (!args.subscriptionId || !uuidValidate(args.subscriptionId)) {
         throw new Error('Bad or missing --subscriptionId');
+        }
 
-    if (!args.resourceGroup || args.resourceGroup.length == 0)
+    if (!args.resourceGroup || args.resourceGroup.length === 0) {
         throw new Error('Bad or missing --resourceGroup');
+        }
 
-    if (!args.connectionString || args.connectionString.length == 0)
+    if (!args.connectionString || args.connectionString.length === 0) {
         throw new Error('Bad or missing --connectionString');
+        }
 
-    if (!args.database || args.database.length == 0)
+    if (!args.database || args.database.length === 0) {
         throw new Error('Bad or missing --database');
+        }
 
-    if (!args.collection || args.collection.length == 0)
+    if (!args.collection || args.collection.length === 0) {
         throw new Error('Bad or missing --collection');
+        }
 
-    let service = new CosmosDbService({
+    const service: CosmosDbService = new CosmosDbService({
         name: args.hasOwnProperty('name') ? args.name : args.serviceName,
         serviceName : args.serviceName,
         tenantId: args.tenantId,
@@ -103,15 +127,17 @@ async function processConnectAzureArgs(config: BotConfiguration): Promise<BotCon
         database: args.database,
         collection: args.collection
     });
-    let id = config.connectService(service);
+    const id: string = config.connectService(service);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -15,12 +15,11 @@ program.Command.prototype.unknownOption = (): void => {
     showErrorHelp();
 };
 
-interface IConnectoCosmosDbArgs extends ICosmosDBService {
+interface IConnectCosmosDbArgs extends ICosmosDBService {
     bot: string;
     secret: string;
     stdin: boolean;
     input?: string;
-    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -41,7 +40,7 @@ program
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
-const args: IConnectoCosmosDbArgs = {
+const args: IConnectCosmosDbArgs = {
     bot: '',
     secret: '',
     stdin: true,
@@ -56,11 +55,7 @@ const args: IConnectoCosmosDbArgs = {
 };
 
 const commands: program.Command = program.parse(process.argv);
-for (const i of commands.args) {
-    if (args.hasOwnProperty(i)) {
-        args[i] = commands[i];
-    }
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();


### PR DESCRIPTION
## Proposed Changes
Fix the following warnings in the file `msbot-connect-cosmosdb.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `quotemark`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `triple-equals`
- `newline-before-return`
- `eofline`

## Testing
Travis will no longer report this issue.