### PR TITLE
Fix TSLint warnings in msbot-connect-dispatch

### DIFF
--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -10,12 +10,12 @@ import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectDispatchArgs extends ILuisService {
+interface IConnectDispatchArgs extends ILuisService {
     bot: string;
     secret: string;
     stdin: boolean;
@@ -30,19 +30,30 @@ program
     .option('-a, --appId <appid>', 'LUID AppId for the dispatch app')
     .option('-v, --version <version>', 'version for the dispatch app, (example: 0.1)')
     .option('--authoringKey <authoringkey>', 'authoring key for using manipulating the dispatch model via the LUIS authoring API\n')
-    .option('r, --region <region>', "region to use (defaults to westus)")
+    .option('r, --region <region>', 'region to use (defaults to westus)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying the dispatch model')
-    .option('--serviceIds <serviceIds>', '(OPTIONAL) comma delimited list of service ids in this bot (qna or luis) to build a dispatch model over.')
+    .option('--serviceIds <serviceIds>',
+            '(OPTIONAL) comma delimited list of service ids in this bot (qna or luis) to build a dispatch model over.')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-    });
-
-let args = <ConnectDispatchArgs><any>program.parse(process.argv);
+const args: IConnectDispatchArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    appId: '',
+    authoringKey: '',
+    subscriptionKey: '',
+    version: '',
+    region: '',
+    name: ''
+};
+const commands: program.Command = program.parse(process.argv);
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();
@@ -50,14 +61,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectDispatch)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectDispatch)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -69,40 +80,52 @@ async function processConnectDispatch(config: BotConfiguration): Promise<BotConf
 
     if (args.stdin) {
         Object.assign(args, JSON.parse(await getStdin()));
-    }
-    else if (args.input != null) {
+    } else if (args.input != null) {
         Object.assign(args, JSON.parse(await txtfile.read(<string>args.input)));
     }
 
-    if (!args.hasOwnProperty('name'))
+    if (!args.hasOwnProperty('name')) {
         throw new Error('Bad or missing --name');
+    }
 
-    if (!args.appId || !uuidValidate(args.appId))
+    if (!args.appId || !uuidValidate(args.appId)) {
         throw new Error('bad or missing --appId');
+    }
 
-    if (!args.version)
+    if (!args.version) {
         throw new Error('bad or missing --version');
+    }
 
-    if (!args.authoringKey || !uuidValidate(args.authoringKey))
+    if (!args.authoringKey || !uuidValidate(args.authoringKey)) {
         throw new Error('bad or missing --authoringKey');
+    }
 
-    if (args.subscriptionKey && !uuidValidate(args.subscriptionKey))
+    if (args.subscriptionKey && !uuidValidate(args.subscriptionKey)) {
         throw new Error('bad --subscriptionKey');
+    }
 
-    const newService = new DispatchService(<IDispatchService><any>args);
+    const dispatchService: ITempDispatchService = {
+        appId: '',
+        authoringKey: '',
+        subscriptionKey: '',
+        version: '',
+        serviceIds: [''],
+        region: '',
+        type: ServiceTypes.Dispatch,
+        name: ''
+    };
+    Object.assign(dispatchService, args);
+    const newService: IDispatchService = new DispatchService(dispatchService);
 
     if (!args.serviceIds) {
         // default to all services as appropriate
-        const dispatchServices = <IConnectedService[]>(<any>args).services;
+        // tslint:disable-next-line:no-any
+        const dispatchServices: IConnectedService[] = <IConnectedService[]>(<any>args).services;
 
         if (<IConnectedService[]>dispatchServices) {
-            for (let service of dispatchServices) {
-                switch (service.type) {
-                    case ServiceTypes.File:
-                    case ServiceTypes.Luis:
-                    case ServiceTypes.QnA:
-                        newService.serviceIds.push(service.id || '');
-                        break;
+            for (const service of dispatchServices) {
+                if (service.type === ServiceTypes.File || service.type === ServiceTypes.Luis || service.type === ServiceTypes.QnA) {
+                    newService.serviceIds.push(service.id || '');
                 }
             }
         }
@@ -111,16 +134,22 @@ async function processConnectDispatch(config: BotConfiguration): Promise<BotConf
     }
 
     // add the service
-    let id =config.connectService(newService);
+    const id: string = config.connectService(newService);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);
+}
+
+interface ITempDispatchService extends IDispatchService {
+    [key: string]: string | string[] | undefined | boolean | IConnectedService[];
 }


### PR DESCRIPTION
## Proposed Changes
Fix the following warnings in the file `msbot-connect-dispatch.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `quotemark`
- `max-line-length`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `switch-default`
- `switch-final-break`
- `whitespace`
- `newline-before-return`
- `eofline`

## Testing
Travis will no longer report this issue.