### PR TITLE
Change TSLint severity from 'warning' to 'error' only for MSBot package

### DIFF
--- a/packages/MSBot/tslint.json
+++ b/packages/MSBot/tslint.json
@@ -1,0 +1,3 @@
+{
+  "defaultSeverity": "error"
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,9 @@
 {
-    "defaultSeverity": "error",
+    "defaultSeverity": "warning",
     "extends": [
         "tslint:recommended",
-        "tslint-microsoft-contrib"
+        "tslint-microsoft-contrib",
+        "./packages/MSBot/tslint.json"
     ],
     "jsRules": {},
     "rules": {},

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-    "defaultSeverity": "warning",
+    "defaultSeverity": "error",
     "extends": [
         "tslint:recommended",
         "tslint-microsoft-contrib"


### PR DESCRIPTION
## Proposed Changes
Change TSLint severity from `warning` to `error` only for the MSBot package. This is done with a new `tslint.json` file inside `MSBot` package. A reference to this file is added in the root `tslint.json` file.

## Testing
Any TSLint warnings inside `MSBot` package will make Travis builds fail