### PR TITLE
Proposed fix to `no-any` TSLint` rule  when parsing commands using `Object.assign()`

### DIFF
--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -23,8 +23,6 @@ interface IInitArgs {
     appId: string;
     appPassword: string;
     quiet: boolean;
-    // tslint:disable-next-line:no-any
-    [key: string]: any;
 }
 
 program
@@ -49,9 +47,7 @@ const args: IInitArgs = {
     appPassword: '',
     quiet: false
 };
-for (const key of args.keys) {
-    args[key] = command[key];
-}
+Object.assign(args, command);
 
 if (!args.quiet) {
 

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -23,7 +23,8 @@ interface IInitArgs {
     appId: string;
     appPassword: string;
     quiet: boolean;
-    [key: string]: string | boolean;
+    // tslint:disable-next-line:no-any
+    [key: string]: any;
 }
 
 program
@@ -38,7 +39,19 @@ program
         console.log(name);
     });
 
-let args  = <IInitArgs><any>program.parse(process.argv);
+const command: program.Command = program.parse(process.argv);
+const args: IInitArgs = {
+    name : '',
+    description: '',
+    secret: false,
+    endpoint: '',
+    appId: '',
+    appPassword: '',
+    quiet: false
+};
+for (const key of args.keys) {
+    args[key] = command[key];
+}
 
 if (!args.quiet) {
 


### PR DESCRIPTION
## Proposed Changes
- Replace the casting of `program.Command` to type `<any>` with `Object.assign()`.
- This also fixes a previous method using a property assignation loop

## Testing
The changes were tested using `msbot-init.ts`.