### PR TITLE
Fix ESLint 'indent' and 'no-constant-condition' warnings in LUIS package

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -89,10 +89,10 @@ async function runProgram() {
 
     // special non-operation commands
     switch (args._[0]) {
-        case "query":
-            return await handleQueryCommand(args, config);
-        case "set":
-            return await handleSetCommand(args, config, client);
+    case "query":
+        return await handleQueryCommand(args, config);
+    case "set":
+        return await handleSetCommand(args, config, client);
     }
     let verb = (args._.length >= 1) ? args._[0].toLowerCase() : undefined;
     let target = (args._.length >= 2) ? args._[1].toLowerCase() : undefined;
@@ -103,487 +103,487 @@ async function runProgram() {
     let result = {};
 
     switch (verb) {
-        // ------------------ ADD  ------------------
-        case "add":
-            switch (target) {
-                case "app":
-                case "application":
-                    result = await client.apps.add(args.region, requestBody, args);
-                    result = await client.apps.get(args.region, result, args);
+    // ------------------ ADD  ------------------
+    case "add":
+        switch (target) {
+        case "app":
+        case "application":
+            result = await client.apps.add(args.region, requestBody, args);
+            result = await client.apps.get(args.region, result, args);
 
-                    // Write output to console and return
-                    writeAppToConsole(config, args, requestBody, result);
-                    return;
-                case "closedlist":
-                    result = await client.model.addClosedList(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "closedlistentityrole":
-                    result = await client.model.createClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "compositeentity":
-                    result = await client.model.addCompositeEntity(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "compositeentitychild":
-                    result = await client.model.addCompositeEntityChild(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
-                    break;
-                case "compositeentityrole":
-                    result = await client.model.createCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
-                    break;
-                case "customprebuiltdomain":
-                    result = await client.model.addCustomPrebuiltDomain(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "customprebuiltentity":
-                    result = await client.model.addCustomPrebuiltEntity(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "customprebuiltentityrole":
-                    result = await client.model.createCustomPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "customprebuiltintent":
-                    result = await client.model.addCustomPrebuiltIntent(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "entity":
-                    result = await client.model.addEntity(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "entityrole":
-                    result = await client.model.createEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "example":
-                    result = await client.examples.add(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "examples":
-                    result = await client.examples.batch(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "explicitlistitem":
-                    result = await client.model.addExplicitListItem(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "hierarchicalentity":
-                    result = await client.model.addHierarchicalEntity(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "hierarchicalentitychild":
-                    result = await client.model.addHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
-                    break;
-                case "hierarchicalentityrole":
-                    result = await client.model.createHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
-                    break;
-                case "intent":
-                    result = await client.model.addIntent(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "pattern":
-                    result = await client.pattern.addPattern(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "patternentityrole":
-                    result = await client.model.createPatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "patterns":
-                    result = await client.pattern.batchAddPatterns(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "permissions":
-                    result = await client.permissions.add(args.region, args.appId, requestBody, args);
-                    break;
-                case "phraselist":
-                    result = await client.features.addPhraseList(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "prebuilt":
-                    result = await client.model.addPrebuilt(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "prebuiltentityrole":
-                    result = await client.model.createPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "regexentity":
-                    result = await client.model.createRegexEntityModel(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "regexentityrole":
-                    result = await client.model.createRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "sublist":
-                    result = await client.model.addSubList(args.region, args.appId, args.versionId, args.clEntityId, requestBody, args);
-                    break;
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+            // Write output to console and return
+            writeAppToConsole(config, args, requestBody, result);
+            return;
+        case "closedlist":
+            result = await client.model.addClosedList(args.region, args.appId, args.versionId, requestBody, args);
             break;
-        // ------------------ CLONE ------------------
-        case "clone":
-            switch (target) {
-                case "version":
-                    result = await client.versions.clone(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "closedlistentityrole":
+            result = await client.model.createClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
             break;
-        // ------------------ DELETE ------------------
-        case "delete":
-            switch (target) {
-                case "app":
-                case "application":
-                    {
-                        let app = await client.apps.get(args.region, args.appId, args);
-                        if (app.error) {
-                            throw new Error(app.error);
-                        }
-                        let answer = readlineSync.question(`Are you sure you want to delete the application ${app.name} (${app.id})? [no] `, { defaultResponse: 'no' });
-                        if (answer.length == 0 || answer[0] != 'y') {
-                            process.stderr.write('delete operation canceled\n');
-                            process.exit(1);
-                            return;
-                        }
-                        result = await client.apps.deleteMethod(args.region, args.appId, args);
-                    }
-                    break;
-
-                case "version":
-                    {
-                        let app = await client.apps.get(args.region, args.appId, args);
-                        if (app.error) {
-                            throw new Error(app.error);
-                        }
-                        let answer = readlineSync.question(`Are you sure you want to delete the application ${app.name} version ${args.versionId}? [no] `, { defaultResponse: 'no' });
-                        if (answer.length == 0 || answer[0] != 'y') {
-                            process.stderr.write('delete operation canceled\n');
-                            process.exit(1);
-                            return;
-                        }
-                        result = await client.versions.deleteMethod(args.region, args.appId, args.versionId, args);
-                    }
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "compositeentity":
+            result = await client.model.addCompositeEntity(args.region, args.appId, args.versionId, requestBody, args);
             break;
-        // ------------------ EXPORT ------------------
-        case "export":
-            switch (target) {
-                case "version":
-                    result = await client.versions.exportMethod(args.region, args.appId, args.versionId, args);
-                    break;
-                case "closedlist":
-                    result = await client.model.getClosedList(args.region, args.appId, args.versionId, args.clEntityId, args);
-                    break;
-                case "closedlistentityrole":
-                    result = await client.model.getClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "compositeentitychild":
+            result = await client.model.addCompositeEntityChild(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
             break;
-        // ------------------ GET ------------------
-        case "get":
-            switch (target) {
-                case "app":
-                case "application":
-                    result = await client.apps.get(args.region, args.appId, args);
-
-                    // Write output to console and return
-                    writeAppToConsole(config, args, requestBody, result);
-                    return;
-
-                case "closedlist":
-                    result = await client.model.getClosedList(args.region, args.appId, args.versionId, args.clEntityId, args);
-                    break;
-                case "closedlistentityrole":
-                    result = await client.model.getClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                case "compositeentity":
-                    result = await client.model.getCompositeEntity(args.region, args.appId, args.versionId, args.cEntityId, args);
-                    break;
-                case "compositeentityrole":
-                    result = await client.model.getCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, args.roleId, args);
-                    break;
-                //case "customprebuiltdomain":
-                //case "customprebuiltentityrole":
-                case "entity":
-                    result = await client.model.getEntity(args.region, args.appId, args.versionId, args.entityId, args);
-                    break;
-                case "entityrole":
-                    result = await client.model.getEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                case "explicitlistitem":
-                    result = await client.model.getExplicitListItem(args.region, args.appId, args.versionId, args.entityId, args.itemId, args);
-                    break;
-                case "hierarchicalentity":
-                    result = await client.model.getHierarchicalEntity(args.region, args.appId, args.versionId, args.hEntityId, args);
-                    break;
-                case "hierarchicalentitychild":
-                    result = await client.model.getHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, args.hChildId, args);
-                    break;
-                case "hierarchicalentityrole":
-                    result = await client.model.getHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, args.roleId, args);
-                    break;
-                case "intent":
-                    result = await client.model.getIntent(args.region, args.appId, args.versionId, args.intentId, args);
-                    break;
-                case "pattern":
-                    result = await client.features.getPatternFeatureInfo(args.region, args.appId, args.versionId, args.patternId, args);
-                    break;
-                case "patternentityrole":
-                    result = await client.model.getPatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                case "phraselist":
-                    result = await client.features.getPhraseList(args.region, args.appId, args.versionId, args.phraselistId, args);
-                    break;
-                case "prebuilt":
-                    result = await client.model.getPrebuilt(args.region, args.appId, args.versionId, args.prebuiltId, args);
-                    break;
-                case "prebuiltentityrole":
-                    result = await client.model.getPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                case "regexentity":
-                    result = await client.model.getRegexEntityEntityInfo(args.region, args.appId, args.versionId, args.regexEntityId, args);
-                    break;
-                case "regexentityrole":
-                    result = await client.model.getRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
-                    break;
-                case "settings":
-                    result = await client.apps.getSettings(args.region, args.appId, requestBody, args);
-                    break;
-                case "status":
-                    result = await client.train.getStatus(args.region, args.appId, args.versionId, args);
-                    if (args.wait) {
-                        result = await waitForTrainingToComplete(client, args);
-                    }
-                    break;
-                case "version":
-                    result = await client.versions.get(args.region, args.appId, args.versionId, args);
-                    break;
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "compositeentityrole":
+            result = await client.model.createCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
             break;
-        // ------------------ IMPORT ------------------
-        case "import":
-            switch (target) {
-                case "app":
-                case "application":
-                    if (args.appName) {
-                        requestBody.name = args.appName;
-                    }
-                    result = await client.apps.importMethod(args.region, requestBody, args);
-                    result = await client.apps.get(args.region, result, args);
-
-                    // Write output to console and return
-                    writeAppToConsole(config, args, requestBody, result);
-                    return;
-
-                case "version":
-                    result = await client.versions.importMethod(args.region, args.appId, requestBody, args);
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "customprebuiltdomain":
+            result = await client.model.addCustomPrebuiltDomain(args.region, args.appId, args.versionId, requestBody, args);
             break;
-
-        // ------------------ INIT ------------------
-        case "init":
+        case "customprebuiltentity":
+            result = await client.model.addCustomPrebuiltEntity(args.region, args.appId, args.versionId, requestBody, args);
             break;
-
-        // ------------------ LIST ------------------
-        case "list":
-            switch (target) {
-                case "apps":
-                case "applications":
-                    result = await client.apps.list(args.region, args);
-                    break;
-                case "credentials":
-                    result = await client.credentials.list(args.region, args.appId, args.versionId, args);
-                    break;
-                case "examples":
-                    result = await client.examples.list(args.region, args.appId, args.versionId, args);
-                    break;
-                case "features":
-                    result = await client.features.list(args.region, args.appId, args.versionId, args);
-                    break;
-                case "patterns":
-                    result = await client.pattern.list(args.region, args.appId, args.versionId, args);
-                    break;
-                case "permissions":
-                    result = await client.permissions.list(args.region, args.appId, args);
-                    break;
-                case "train":
-                    result = await client.train.list(args.region, args.appId, args.versionId, args);
-                    break;
-                case "versions":
-                    result = await client.versions.list(args.region, args.appId, args);
-                    break;
-                // --- model methods---
-                case "closedlists":
-                    result = await client.model.listClosedLists(args.region, args.appId, args.versionId, args);
-                    break;
-                case "compositeentities":
-                    result = await client.model.listCompositeEntities(args.region, args.appId, args.versionId, args);
-                    break;
-                case "customprebuiltentities":
-                    result = await client.model.listCustomPrebuiltEntities(args.region, args.appId, args.versionId, args);
-                    break;
-                case "customprebuiltintents":
-                    result = await client.model.listCustomPrebuiltIntents(args.region, args.appId, args.versionId, args);
-                    break;
-                case "customprebuiltmodels":
-                    result = await client.model.listCustomPrebuiltModels(args.region, args.appId, args.versionId, args);
-                    break;
-                case "entities":
-                    result = await client.model.listEntities(args.region, args.appId, args.versionId, args);
-                    break;
-                case "hierarchicalentities":
-                    result = await client.model.listHierarchicalEntities(args.region, args.appId, args.versionId, args);
-                    break;
-                case "intents":
-                    result = await client.model.listIntents(args.region, args.appId, args.versionId, args);
-                    break;
-                case "models":
-                    result = await client.model.listModels(args.region, args.appId, args.versionId, args);
-                    break;
-                case "prebuiltentities":
-                    result = await client.model.listPrebuiltEntities(args.region, args.appId, args.versionId, args);
-                    break;
-                case "prebuilts":
-                    result = await client.model.listPrebuilts(args.region, args.appId, args.versionId, args);
-                    break;
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "customprebuiltentityrole":
+            result = await client.model.createCustomPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
             break;
-        // ------------------ PUBLISH ------------------
-        case "publish":
-            switch (target) {
-                case "version":
-                    result = await client.apps.publish(args.region, args.appId, requestBody, args);
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "customprebuiltintent":
+            result = await client.model.addCustomPrebuiltIntent(args.region, args.appId, args.versionId, requestBody, args);
             break;
-        // ------------------ SUGGEST ------------------
-        case "suggest":
-            switch (target) {
-                case "intents":
-                    result = await client.apps.publish(args.region, args.appId, requestBody, args);
-                    break;
-                case "entities":
-                    result = await client.apps.publish(args.region, args.appId, requestBody, args);
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "entity":
+            result = await client.model.addEntity(args.region, args.appId, args.versionId, requestBody, args);
             break;
-        // ------------------ TRAIN ------------------
-        case "train":
-            switch (target) {
-                case "version":
-                    result = await client.train.trainVersion(args.region, args.appId, args.versionId, args);
-
-                    if (args.wait) {
-                        result = await waitForTrainingToComplete(client, args);
-                    }
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "entityrole":
+            result = await client.model.createEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
             break;
-
-        // ------------------- RENAME ----------------
-        case "rename":
-            switch (target) {
-
-                case "version":
-                    result = await client.versions.update(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "example":
+            result = await client.examples.add(args.region, args.appId, args.versionId, requestBody, args);
             break;
-
-        // ------------------ UPDATE ------------------
-        case "update":
-            switch (target) {
-                case "app":
-                case "application":
-                    result = await client.apps.update(args.region, args.appId, requestBody, args);
-                    break;
-                case "closedlist":
-                    result = await client.model.updateClosedList(args.region, args.appId, args.versionId, args.clEntityId, requestBody, args);
-                    break;
-                case "closedlistentityrole":
-                    result = await client.model.updateClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "compositeentity":
-                    result = await client.model.updateCompositeEntity(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
-                    break;
-                case "compositeentityrole":
-                    result = await client.model.updateCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, args.roleId, requestBody, args);
-                    break;
-                case "customprebuiltentityrole":
-                    result = await client.model.updateCustomPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "entity":
-                    result = await client.model.updateEntity(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "entityrole":
-                    result = await client.model.updateEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "explicitlistitem":
-                    result = await client.model.updateExplicitListItem(args.region, args.appId, args.versionId, args.entityId, args.itemId, requestBody, args);
-                    break;
-                case "hierarchicalentity":
-                    result = await client.model.updateHierarchicalEntity(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
-                    break;
-                case "hierarchicalentitychild":
-                    result = await client.model.updateHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, args.hChildId, requestBody, args);
-                    break;
-                case "hierarchicalentityrole":
-                    result = await client.model.updateHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, args.roleId, requestBody, args);
-                    break;
-                case "intent":
-                    result = await client.model.updateIntent(args.region, args.appId, args.versionId, args.intentId, requestBody, args);
-                    break;
-                case "pattern":
-                    result = await client.model.updatePatternAnyEntityModel(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
-                    break;
-                case "patternentityrole":
-                    result = await client.model.updatePatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "patterns":
-                    result = await client.pattern.updatePatterns(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "permissions":
-                    result = await client.permissions.update(args.region, args.appId, requestBody, args);
-                    break;
-                case "phraselist":
-                    result = await client.features.updatePhraseList(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-                case "prebuiltentityrole":
-                    result = await client.model.updatePrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "regexentity":
-                    result = await client.model.updateRegexEntityModel(args.region, args.appId, args.versionId, args.regexEntityId, requestBody, args);
-                    break;
-                case "regexentityrole":
-                    result = await client.model.updateRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
-                    break;
-                case "settings":
-                    result = await client.apps.updateSettings(args.region, args.appId, requestBody, args);
-                    break;
-                case "sublist":
-                    result = await client.model.updateSubList(args.region, args.appId, args.versionId, args.clEntityId, args.subListId, requestBody, args);
-                    break;
-                case "version":
-                    result = await client.versions.update(args.region, args.appId, args.versionId, requestBody, args);
-                    break;
-
-                default:
-                    throw new Error(`Unknown resource: ${target}`);
-            }
+        case "examples":
+            result = await client.examples.batch(args.region, args.appId, args.versionId, requestBody, args);
             break;
-
+        case "explicitlistitem":
+            result = await client.model.addExplicitListItem(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "hierarchicalentity":
+            result = await client.model.addHierarchicalEntity(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "hierarchicalentitychild":
+            result = await client.model.addHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
+            break;
+        case "hierarchicalentityrole":
+            result = await client.model.createHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
+            break;
+        case "intent":
+            result = await client.model.addIntent(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "pattern":
+            result = await client.pattern.addPattern(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "patternentityrole":
+            result = await client.model.createPatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "patterns":
+            result = await client.pattern.batchAddPatterns(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "permissions":
+            result = await client.permissions.add(args.region, args.appId, requestBody, args);
+            break;
+        case "phraselist":
+            result = await client.features.addPhraseList(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "prebuilt":
+            result = await client.model.addPrebuilt(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "prebuiltentityrole":
+            result = await client.model.createPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "regexentity":
+            result = await client.model.createRegexEntityModel(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "regexentityrole":
+            result = await client.model.createRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "sublist":
+            result = await client.model.addSubList(args.region, args.appId, args.versionId, args.clEntityId, requestBody, args);
+            break;
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ CLONE ------------------
+    case "clone":
+        switch (target) {
+        case "version":
+            result = await client.versions.clone(args.region, args.appId, args.versionId, requestBody, args);
+            break;
 
         default:
-            throw new Error(`Unknown verb: ${verb}`);
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ DELETE ------------------
+    case "delete":
+        switch (target) {
+        case "app":
+        case "application":
+            {
+                let app = await client.apps.get(args.region, args.appId, args);
+                if (app.error) {
+                    throw new Error(app.error);
+                }
+                let answer = readlineSync.question(`Are you sure you want to delete the application ${app.name} (${app.id})? [no] `, { defaultResponse: 'no' });
+                if (answer.length == 0 || answer[0] != 'y') {
+                    process.stderr.write('delete operation canceled\n');
+                    process.exit(1);
+                    return;
+                }
+                result = await client.apps.deleteMethod(args.region, args.appId, args);
+            }
+            break;
+
+        case "version":
+            {
+                let app = await client.apps.get(args.region, args.appId, args);
+                if (app.error) {
+                    throw new Error(app.error);
+                }
+                let answer = readlineSync.question(`Are you sure you want to delete the application ${app.name} version ${args.versionId}? [no] `, { defaultResponse: 'no' });
+                if (answer.length == 0 || answer[0] != 'y') {
+                    process.stderr.write('delete operation canceled\n');
+                    process.exit(1);
+                    return;
+                }
+                result = await client.versions.deleteMethod(args.region, args.appId, args.versionId, args);
+            }
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ EXPORT ------------------
+    case "export":
+        switch (target) {
+        case "version":
+            result = await client.versions.exportMethod(args.region, args.appId, args.versionId, args);
+            break;
+        case "closedlist":
+            result = await client.model.getClosedList(args.region, args.appId, args.versionId, args.clEntityId, args);
+            break;
+        case "closedlistentityrole":
+            result = await client.model.getClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ GET ------------------
+    case "get":
+        switch (target) {
+        case "app":
+        case "application":
+            result = await client.apps.get(args.region, args.appId, args);
+
+            // Write output to console and return
+            writeAppToConsole(config, args, requestBody, result);
+            return;
+
+        case "closedlist":
+            result = await client.model.getClosedList(args.region, args.appId, args.versionId, args.clEntityId, args);
+            break;
+        case "closedlistentityrole":
+            result = await client.model.getClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        case "compositeentity":
+            result = await client.model.getCompositeEntity(args.region, args.appId, args.versionId, args.cEntityId, args);
+            break;
+        case "compositeentityrole":
+            result = await client.model.getCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, args.roleId, args);
+            break;
+        //case "customprebuiltdomain":
+        //case "customprebuiltentityrole":
+        case "entity":
+            result = await client.model.getEntity(args.region, args.appId, args.versionId, args.entityId, args);
+            break;
+        case "entityrole":
+            result = await client.model.getEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        case "explicitlistitem":
+            result = await client.model.getExplicitListItem(args.region, args.appId, args.versionId, args.entityId, args.itemId, args);
+            break;
+        case "hierarchicalentity":
+            result = await client.model.getHierarchicalEntity(args.region, args.appId, args.versionId, args.hEntityId, args);
+            break;
+        case "hierarchicalentitychild":
+            result = await client.model.getHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, args.hChildId, args);
+            break;
+        case "hierarchicalentityrole":
+            result = await client.model.getHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, args.roleId, args);
+            break;
+        case "intent":
+            result = await client.model.getIntent(args.region, args.appId, args.versionId, args.intentId, args);
+            break;
+        case "pattern":
+            result = await client.features.getPatternFeatureInfo(args.region, args.appId, args.versionId, args.patternId, args);
+            break;
+        case "patternentityrole":
+            result = await client.model.getPatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        case "phraselist":
+            result = await client.features.getPhraseList(args.region, args.appId, args.versionId, args.phraselistId, args);
+            break;
+        case "prebuilt":
+            result = await client.model.getPrebuilt(args.region, args.appId, args.versionId, args.prebuiltId, args);
+            break;
+        case "prebuiltentityrole":
+            result = await client.model.getPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        case "regexentity":
+            result = await client.model.getRegexEntityEntityInfo(args.region, args.appId, args.versionId, args.regexEntityId, args);
+            break;
+        case "regexentityrole":
+            result = await client.model.getRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, args);
+            break;
+        case "settings":
+            result = await client.apps.getSettings(args.region, args.appId, requestBody, args);
+            break;
+        case "status":
+            result = await client.train.getStatus(args.region, args.appId, args.versionId, args);
+            if (args.wait) {
+                result = await waitForTrainingToComplete(client, args);
+            }
+            break;
+        case "version":
+            result = await client.versions.get(args.region, args.appId, args.versionId, args);
+            break;
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ IMPORT ------------------
+    case "import":
+        switch (target) {
+        case "app":
+        case "application":
+            if (args.appName) {
+                requestBody.name = args.appName;
+            }
+            result = await client.apps.importMethod(args.region, requestBody, args);
+            result = await client.apps.get(args.region, result, args);
+
+            // Write output to console and return
+            writeAppToConsole(config, args, requestBody, result);
+            return;
+
+        case "version":
+            result = await client.versions.importMethod(args.region, args.appId, requestBody, args);
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+
+    // ------------------ INIT ------------------
+    case "init":
+        break;
+
+    // ------------------ LIST ------------------
+    case "list":
+        switch (target) {
+        case "apps":
+        case "applications":
+            result = await client.apps.list(args.region, args);
+            break;
+        case "credentials":
+            result = await client.credentials.list(args.region, args.appId, args.versionId, args);
+            break;
+        case "examples":
+            result = await client.examples.list(args.region, args.appId, args.versionId, args);
+            break;
+        case "features":
+            result = await client.features.list(args.region, args.appId, args.versionId, args);
+            break;
+        case "patterns":
+            result = await client.pattern.list(args.region, args.appId, args.versionId, args);
+            break;
+        case "permissions":
+            result = await client.permissions.list(args.region, args.appId, args);
+            break;
+        case "train":
+            result = await client.train.list(args.region, args.appId, args.versionId, args);
+            break;
+        case "versions":
+            result = await client.versions.list(args.region, args.appId, args);
+            break;
+        // --- model methods---
+        case "closedlists":
+            result = await client.model.listClosedLists(args.region, args.appId, args.versionId, args);
+            break;
+        case "compositeentities":
+            result = await client.model.listCompositeEntities(args.region, args.appId, args.versionId, args);
+            break;
+        case "customprebuiltentities":
+            result = await client.model.listCustomPrebuiltEntities(args.region, args.appId, args.versionId, args);
+            break;
+        case "customprebuiltintents":
+            result = await client.model.listCustomPrebuiltIntents(args.region, args.appId, args.versionId, args);
+            break;
+        case "customprebuiltmodels":
+            result = await client.model.listCustomPrebuiltModels(args.region, args.appId, args.versionId, args);
+            break;
+        case "entities":
+            result = await client.model.listEntities(args.region, args.appId, args.versionId, args);
+            break;
+        case "hierarchicalentities":
+            result = await client.model.listHierarchicalEntities(args.region, args.appId, args.versionId, args);
+            break;
+        case "intents":
+            result = await client.model.listIntents(args.region, args.appId, args.versionId, args);
+            break;
+        case "models":
+            result = await client.model.listModels(args.region, args.appId, args.versionId, args);
+            break;
+        case "prebuiltentities":
+            result = await client.model.listPrebuiltEntities(args.region, args.appId, args.versionId, args);
+            break;
+        case "prebuilts":
+            result = await client.model.listPrebuilts(args.region, args.appId, args.versionId, args);
+            break;
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ PUBLISH ------------------
+    case "publish":
+        switch (target) {
+        case "version":
+            result = await client.apps.publish(args.region, args.appId, requestBody, args);
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ SUGGEST ------------------
+    case "suggest":
+        switch (target) {
+        case "intents":
+            result = await client.apps.publish(args.region, args.appId, requestBody, args);
+            break;
+        case "entities":
+            result = await client.apps.publish(args.region, args.appId, requestBody, args);
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+    // ------------------ TRAIN ------------------
+    case "train":
+        switch (target) {
+        case "version":
+            result = await client.train.trainVersion(args.region, args.appId, args.versionId, args);
+
+            if (args.wait) {
+                result = await waitForTrainingToComplete(client, args);
+            }
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+
+    // ------------------- RENAME ----------------
+    case "rename":
+        switch (target) {
+
+        case "version":
+            result = await client.versions.update(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+
+    // ------------------ UPDATE ------------------
+    case "update":
+        switch (target) {
+        case "app":
+        case "application":
+            result = await client.apps.update(args.region, args.appId, requestBody, args);
+            break;
+        case "closedlist":
+            result = await client.model.updateClosedList(args.region, args.appId, args.versionId, args.clEntityId, requestBody, args);
+            break;
+        case "closedlistentityrole":
+            result = await client.model.updateClosedListEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "compositeentity":
+            result = await client.model.updateCompositeEntity(args.region, args.appId, args.versionId, args.cEntityId, requestBody, args);
+            break;
+        case "compositeentityrole":
+            result = await client.model.updateCompositeEntityRole(args.region, args.appId, args.versionId, args.cEntityId, args.roleId, requestBody, args);
+            break;
+        case "customprebuiltentityrole":
+            result = await client.model.updateCustomPrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "entity":
+            result = await client.model.updateEntity(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "entityrole":
+            result = await client.model.updateEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "explicitlistitem":
+            result = await client.model.updateExplicitListItem(args.region, args.appId, args.versionId, args.entityId, args.itemId, requestBody, args);
+            break;
+        case "hierarchicalentity":
+            result = await client.model.updateHierarchicalEntity(args.region, args.appId, args.versionId, args.hEntityId, requestBody, args);
+            break;
+        case "hierarchicalentitychild":
+            result = await client.model.updateHierarchicalEntityChild(args.region, args.appId, args.versionId, args.hEntityId, args.hChildId, requestBody, args);
+            break;
+        case "hierarchicalentityrole":
+            result = await client.model.updateHierarchicalEntityRole(args.region, args.appId, args.versionId, args.hEntityId, args.roleId, requestBody, args);
+            break;
+        case "intent":
+            result = await client.model.updateIntent(args.region, args.appId, args.versionId, args.intentId, requestBody, args);
+            break;
+        case "pattern":
+            result = await client.model.updatePatternAnyEntityModel(args.region, args.appId, args.versionId, args.entityId, requestBody, args);
+            break;
+        case "patternentityrole":
+            result = await client.model.updatePatternAnyEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "patterns":
+            result = await client.pattern.updatePatterns(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "permissions":
+            result = await client.permissions.update(args.region, args.appId, requestBody, args);
+            break;
+        case "phraselist":
+            result = await client.features.updatePhraseList(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+        case "prebuiltentityrole":
+            result = await client.model.updatePrebuiltEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "regexentity":
+            result = await client.model.updateRegexEntityModel(args.region, args.appId, args.versionId, args.regexEntityId, requestBody, args);
+            break;
+        case "regexentityrole":
+            result = await client.model.updateRegexEntityRole(args.region, args.appId, args.versionId, args.entityId, args.roleId, requestBody, args);
+            break;
+        case "settings":
+            result = await client.apps.updateSettings(args.region, args.appId, requestBody, args);
+            break;
+        case "sublist":
+            result = await client.model.updateSubList(args.region, args.appId, args.versionId, args.clEntityId, args.subListId, requestBody, args);
+            break;
+        case "version":
+            result = await client.versions.update(args.region, args.appId, args.versionId, requestBody, args);
+            break;
+
+        default:
+            throw new Error(`Unknown resource: ${target}`);
+        }
+        break;
+
+
+    default:
+        throw new Error(`Unknown verb: ${verb}`);
     }
 
     if (result && result.error) {
@@ -791,44 +791,44 @@ async function validateArguments(args, operation) {
         else {
             // make up a request body from command line args
             switch (operation.target[0]) {
-                case "version":
-                    switch (operation.methodAlias) {
-                        case "publish":
-                            if (args.region && args.versionId) {
-                                body = {
-                                    versionId: `${args.versionId}`,
-                                    isStaging: args.staging === 'true',
-                                    region: args.region
-                                };
-                            }
-                            break;
-                        case "rename":
-                        case "update":
-                        case "clone":
-                            if (args.newVersionId) {
-                                body = {
-                                    version: `${args.newVersionId}`
-                                };
-                            }
-                            break;
+            case "version":
+                switch (operation.methodAlias) {
+                case "publish":
+                    if (args.region && args.versionId) {
+                        body = {
+                            versionId: `${args.versionId}`,
+                            isStaging: args.staging === 'true',
+                            region: args.region
+                        };
                     }
                     break;
-
-                case "settings":
-                    switch (operation.methodAlias) {
-                        case "update":
-                            if (args.hasOwnProperty("public")) {
-                                body = {
-                                    isPublic : args.public === 'true'
-                                };
-                            }
-                            break;
+                case "rename":
+                case "update":
+                case "clone":
+                    if (args.newVersionId) {
+                        body = {
+                            version: `${args.newVersionId}`
+                        };
                     }
                     break;
+                }
+                break;
 
-                default:
-                    error.message = `The --in requires an input of type: ${operation.entityType}`;
-                    throw error;
+            case "settings":
+                switch (operation.methodAlias) {
+                case "update":
+                    if (args.hasOwnProperty("public")) {
+                        body = {
+                            isPublic : args.public === 'true'
+                        };
+                    }
+                    break;
+                }
+                break;
+
+            default:
+                error.message = `The --in requires an input of type: ${operation.entityType}`;
+                throw error;
             }
         }
     }

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -681,7 +681,8 @@ async function initializeConfig() {
 }
 
 async function waitForTrainingToComplete(client, args) {
-    do {
+    // eslint-disable-next-line no-constant-condition
+    while (true) { 
         let result = await client.train.getStatus(args.region, args.appId, args.versionId, args);
         // get completed or up to date items
         let completedItems = result.filter(item => { return (item.details.status == "Success") || (item.details.status == "UpToDate") });
@@ -690,7 +691,7 @@ async function waitForTrainingToComplete(client, args) {
         if (failedItems.length !== 0) throw new Error(`Training failed for ${failedItems[0].modelId}: ${failedItems[0].details.failureReason}`);
         process.stderr.write(`${completedItems.length}/${result.length} complete.\r`);
         await Delay(1000);
-    } while (true);
+    }
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes
- Correct the mistakenly indentation of the `case` clause inside a `switch` statement.
- Add exception to ESLint check in line with `no-constant-condition` due to the need of a `while(true)` statement to always execute the code inside the said clause.

## Testing
ESLint check should not warn about wrong indentation or `no-constant-condition`. In case ESLint rules severity is set to `error`, Travis build should not fail.