### PR TITLE
Add configuration in 'tslint.json' to exclude a specific path with autogenerated code

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,11 @@
         "tslint:recommended",
         "tslint-microsoft-contrib"
     ],
+    "linterOptions": {
+      "exclude": [
+        "packages/LUIS/src/**"
+      ]
+    },
     "jsRules": {},
     "rules": {},
     "rulesDirectory": [


### PR DESCRIPTION
## Proposed Changes
Add configuration in the `tslint.json` to exclude the path `"packages/LUIS/src/**"` from the TSLint check as this path only contains autogenerated code.

## Testing
TSLint shouldn't detect any warning in files located in this path.