### PR TITLE
Disable TSLint rule in MSBot connect files

### DIFF
--- a/build.ci.sh
+++ b/build.ci.sh
@@ -18,7 +18,7 @@ main() {
             npm run build
             npm run eslint
             npm run tslint
-            npm run coverage
+            npm run coveralls
         )
 
     fi

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "scripts": {
         "build": "lerna bootstrap && lerna run build",
         "test": "lerna run test --parallel",
-        "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+        "coverage": "nyc npm test",
+        "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
         "eslint": "eslint --format \"node_modules/eslint-friendly-formatter\" \"./packages/**/*.js\" \"./packages/@(Dispatch|LUIS|LUISGen|QnAMaker)/bin/*\"",
         "tslint": "tslint ./packages/*/src/**/*.ts -t verbose"
     },

--- a/packages/MSBot/src/msbot-connect-appinsights.ts
+++ b/packages/MSBot/src/msbot-connect-appinsights.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { AppInsightsService, BotConfiguration, IAppInsightsService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BlobStorageService, BotConfiguration, IBlobStorageService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-bot.ts
+++ b/packages/MSBot/src/msbot-connect-bot.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, BotService, EndpointService, IBotService, IConnectedService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, CosmosDbService, ICosmosDBService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, DispatchService, IConnectedService, IDispatchService, ILuisService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, EndpointService, IEndpointService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration, FileService, IFileService, ConnectedService } from 'botframework-config';
+// tslint:disable:no-object-literal-type-assertion
+import { BotConfiguration, FileService, IFileService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';

--- a/packages/MSBot/src/msbot-connect-generic.ts
+++ b/packages/MSBot/src/msbot-connect-generic.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, GenericService, IGenericService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, ILuisService, LuisService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, IQnAService, QnaMakerService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/QnAMaker/test/qnamaker.cli.test.suite.js
+++ b/packages/QnAMaker/test/qnamaker.cli.test.suite.js
@@ -101,7 +101,6 @@ describe('The QnA Maker cli bin', () => {
 
         it('should create the kb when --msbot is used', function(done) {
             if (!subscriptionKey) this.skip('subscriptionKey not found');
-            this.timeout(15000);
             exec(`node ${qnamaker} --subscriptionKey ${subscriptionKey} create kb --in ${createKb} --msbot`, (error, stdout, stderr) => {
                 if (stdout) {
                     assert(stderr.includes('Succeeded'));


### PR DESCRIPTION
## Proposed Changes
Disable rule `no-object-literal-type-assertion` in various MSBot `*connect` files.

## Testing
Travis will no longer report these warnings