### PR TITLE
Disable TSLint rule for no-object-literal-type-assertion

### DIFF
--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, BotRecipe, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-get.ts
+++ b/packages/MSBot/src/msbot-get.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, EndpointService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';

--- a/packages/MSBot/src/processUtils.ts
+++ b/packages/MSBot/src/processUtils.ts
@@ -29,7 +29,7 @@ export function spawnAsync(command: string, stdout?: (data: string) => void, std
             if (code > 0) {
                 reject(` ${code}`);
             } else {
-                resolve(out); }
+                resolve(out);
             }
         });
     });

--- a/packages/MSBot/src/processUtils.ts
+++ b/packages/MSBot/src/processUtils.ts
@@ -29,7 +29,7 @@ export function spawnAsync(command: string, stdout?: (data: string) => void, std
             if (code > 0) {
                 reject(` ${code}`);
             } else {
-                resolve(out);
+                resolve(out); }
             }
         });
     });


### PR DESCRIPTION
## Proposed Changes
Disable rule `no-object-literal-type-assertion` in several MSBot files.

## Testing
Travis will no longer report these warnings