### PR TITLE
Fix ESLint 'indent' warnings in Ludown and QnAMaker packages

### DIFF
--- a/packages/Ludown/lib/translate.js
+++ b/packages/Ludown/lib/translate.js
@@ -64,7 +64,7 @@ const translateModule = {
                 throw(err);
             }
             filesToParse.splice(0,1);
-         }
+        }
     }
 }
 

--- a/packages/Ludown/test/ludown.roleTests.test.suite.js
+++ b/packages/Ludown/test/ludown.roleTests.test.suite.js
@@ -24,12 +24,12 @@ describe('Roles in LU files', function() {
         
         $name: simple`;
         parser.parseFile(fileContent, false, null)
-        .then(res => {
-            assert.equal(res.LUISJsonStructure.entities[0].name, 'name');
-            assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['userName']);
-            done();
-        })
-        .catch(err => done(err));
+            .then(res => {
+                assert.equal(res.LUISJsonStructure.entities[0].name, 'name');
+                assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['userName']);
+                done();
+            })
+            .catch(err => done(err));
     });
 
     it('Correctly parses multiple role definitions in LU files correctly', function(done) {
@@ -77,15 +77,15 @@ describe('Roles in LU files', function() {
 
         `;
         parser.parseFile(fileContent, false, null)
-        .then(res => {
-            assert.equal(res.LUISJsonStructure.entities[0].name, 'entity');
-            assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['foo']);
-            assert.equal(res.LUISJsonStructure.patternAnyEntities[0].name, 'name');
-            assert.deepEqual(res.LUISJsonStructure.patternAnyEntities[0].roles, ['userName', 'userFirstName']);
-            assert.equal(res.LUISJsonStructure.prebuiltEntities[0].name, 'datetimeV2');
-            assert.deepEqual(res.LUISJsonStructure.prebuiltEntities[0].roles, ['startTime', 'deleteTime']);
-            done();
-        })
-        .catch(err => done(err));
+            .then(res => {
+                assert.equal(res.LUISJsonStructure.entities[0].name, 'entity');
+                assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['foo']);
+                assert.equal(res.LUISJsonStructure.patternAnyEntities[0].name, 'name');
+                assert.deepEqual(res.LUISJsonStructure.patternAnyEntities[0].roles, ['userName', 'userFirstName']);
+                assert.equal(res.LUISJsonStructure.prebuiltEntities[0].name, 'datetimeV2');
+                assert.deepEqual(res.LUISJsonStructure.prebuiltEntities[0].roles, ['startTime', 'deleteTime']);
+                done();
+            })
+            .catch(err => done(err));
     });
 });

--- a/packages/Ludown/test/testcases/testcases-data.js
+++ b/packages/Ludown/test/testcases/testcases-data.js
@@ -16,32 +16,32 @@ module.exports.tests = {
         - you are
         `,
         "luisJSON": {
-          "intents": [],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [
-            {
-              "name": "ChocolateType",
-              "mode": false,
-              "words": "m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix",
-              "activated": true
-            },
-            {
-              "name": "question",
-              "mode": true,
-              "words": "are you,you are",
-              "activated": true
-            }
-          ],
-          "regex_features": [],
-          "utterances": [],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            "intents": [],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [
+                {
+                    "name": "ChocolateType",
+                    "mode": false,
+                    "words": "m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix",
+                    "activated": true
+                },
+                {
+                    "name": "question",
+                    "mode": true,
+                    "words": "are you,you are",
+                    "activated": true
+                }
+            ],
+            "regex_features": [],
+            "utterances": [],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
-        },
+    },
     "all-entity-types": {
         "lufile":`$userName:simple
         $PREBUILT:datetimeV2
@@ -64,85 +64,85 @@ module.exports.tests = {
             - phone
         `,
         "luisJSON":{
-          "intents": [],
-          "entities": [
-            {
-              "name": "userName",
-              "roles": []
-            }
-          ],
-          "composites": [],
-          "closedLists": [
-            {
-              "name": "commPreference",
-              "subLists": [
+            "intents": [],
+            "entities": [
                 {
-                  "canonicalForm": "call",
-                  "list": [
-                    "phone call",
-                    "give me a ring",
-                    "ring",
-                    "call",
-                    "cell phone",
-                    "phone"
-                  ]
+                    "name": "userName",
+                    "roles": []
                 }
-              ],
-              "roles": []
-            }
-          ],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [
-            {
-              "name": "datetimeV2",
-              "roles": []
-            },
-            {
-              "name": "age",
-              "roles": []
-            },
-            {
-              "name": "dimension",
-              "roles": []
-            },
-            {
-              "name": "email",
-              "roles": []
-            },
-            {
-              "name": "money",
-              "roles": []
-            },
-            {
-              "name": "number",
-              "roles": []
-            },
-            {
-              "name": "ordinal",
-              "roles": []
-            },
-            {
-              "name": "percentage",
-              "roles": []
-            },
-            {
-              "name": "phoneNumber",
-              "roles": []
-            },
-            {
-              "name": "temperature",
-              "roles": []
-            },
-            {
-              "name": "url",
-              "roles": []
-            }
-          ],
+            ],
+            "composites": [],
+            "closedLists": [
+                {
+                    "name": "commPreference",
+                    "subLists": [
+                        {
+                            "canonicalForm": "call",
+                            "list": [
+                                "phone call",
+                                "give me a ring",
+                                "ring",
+                                "call",
+                                "cell phone",
+                                "phone"
+                            ]
+                        }
+                    ],
+                    "roles": []
+                }
+            ],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [
+                {
+                    "name": "datetimeV2",
+                    "roles": []
+                },
+                {
+                    "name": "age",
+                    "roles": []
+                },
+                {
+                    "name": "dimension",
+                    "roles": []
+                },
+                {
+                    "name": "email",
+                    "roles": []
+                },
+                {
+                    "name": "money",
+                    "roles": []
+                },
+                {
+                    "name": "number",
+                    "roles": []
+                },
+                {
+                    "name": "ordinal",
+                    "roles": []
+                },
+                {
+                    "name": "percentage",
+                    "roles": []
+                },
+                {
+                    "name": "phoneNumber",
+                    "roles": []
+                },
+                {
+                    "name": "temperature",
+                    "roles": []
+                },
+                {
+                    "name": "url",
+                    "roles": []
+                }
+            ],
         }
     },
     "3-intents-patterns":{
@@ -155,58 +155,58 @@ module.exports.tests = {
         - {userName} is my name
         - you can call me {userName}`,
         "luisJSON":{
-          "intents": [
-            {
-              "name": "AskForUserName"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "{userName}",
-              "intent": "AskForUserName",
-              "entities": []
-            }
-          ],
-          "patterns": [
-            {
-              "pattern": "{userName}",
-              "intent": "AskForUserName"
-            },
-            {
-              "pattern": "I'm {userName}",
-              "intent": "AskForUserName"
-            },
-            {
-              "pattern": "call me {userName}",
-              "intent": "AskForUserName"
-            },
-            {
-              "pattern": "my name is {userName}",
-              "intent": "AskForUserName"
-            },
-            {
-              "pattern": "{userName} is my name",
-              "intent": "AskForUserName"
-            },
-            {
-              "pattern": "you can call me {userName}",
-              "intent": "AskForUserName"
-            }
-          ],
-          "patternAnyEntities": [
-            {
-              "name": "userName",
-              "explicitList": [],
-              "roles": []
-            }
-          ],
-          "prebuiltEntities": [],
+            "intents": [
+                {
+                    "name": "AskForUserName"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "{userName}",
+                    "intent": "AskForUserName",
+                    "entities": []
+                }
+            ],
+            "patterns": [
+                {
+                    "pattern": "{userName}",
+                    "intent": "AskForUserName"
+                },
+                {
+                    "pattern": "I'm {userName}",
+                    "intent": "AskForUserName"
+                },
+                {
+                    "pattern": "call me {userName}",
+                    "intent": "AskForUserName"
+                },
+                {
+                    "pattern": "my name is {userName}",
+                    "intent": "AskForUserName"
+                },
+                {
+                    "pattern": "{userName} is my name",
+                    "intent": "AskForUserName"
+                },
+                {
+                    "pattern": "you can call me {userName}",
+                    "intent": "AskForUserName"
+                }
+            ],
+            "patternAnyEntities": [
+                {
+                    "name": "userName",
+                    "explicitList": [],
+                    "roles": []
+                }
+            ],
+            "prebuiltEntities": [],
         }
     },
     "2-intent": {
@@ -221,60 +221,60 @@ module.exports.tests = {
         - I need help
         - please help`,
         "luisJSON": {
-          "intents": [
-            {
-              "name": "Greeting"
-            },
-            {
-              "name": "Help"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "Hi",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Hello",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Good morning",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Good evening",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "help",
-              "intent": "Help",
-              "entities": []
-            },
-            {
-              "text": "I need help",
-              "intent": "Help",
-              "entities": []
-            },
-            {
-              "text": "please help",
-              "intent": "Help",
-              "entities": []
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            "intents": [
+                {
+                    "name": "Greeting"
+                },
+                {
+                    "name": "Help"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "Hi",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Hello",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Good morning",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Good evening",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "help",
+                    "intent": "Help",
+                    "entities": []
+                },
+                {
+                    "text": "I need help",
+                    "intent": "Help",
+                    "entities": []
+                },
+                {
+                    "text": "please help",
+                    "intent": "Help",
+                    "entities": []
+                }
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
     },
     "2-intent-scattered-list": {
@@ -304,76 +304,76 @@ module.exports.tests = {
         $commPreference:fax=
             - fax
             - fascimile`,
-            "luisJSON": {
-              "intents": [
+        "luisJSON": {
+            "intents": [
                 {
-                  "name": "CommunicationPreference"
+                    "name": "CommunicationPreference"
                 },
                 {
-                  "name": "Help"
+                    "name": "Help"
                 }
-              ],
-              "entities": [],
-              "composites": [],
-              "closedLists": [
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [
                 {
-                  "name": "commPreference",
-                  "subLists": [
-                    {
-                      "canonicalForm": "call",
-                      "list": [
-                        "phone call",
-                        "give me a ring",
-                        "ring",
-                        "call",
-                        "cell phone",
-                        "phone"
-                      ]
-                    },
-                    {
-                      "canonicalForm": "text",
-                      "list": [
-                        "message",
-                        "text",
-                        "sms",
-                        "text message"
-                      ]
-                    },
-                    {
-                      "canonicalForm": "fax",
-                      "list": [
-                        "fax",
-                        "fascimile"
-                      ]
-                    }
-                  ],
-                  "roles": []
+                    "name": "commPreference",
+                    "subLists": [
+                        {
+                            "canonicalForm": "call",
+                            "list": [
+                                "phone call",
+                                "give me a ring",
+                                "ring",
+                                "call",
+                                "cell phone",
+                                "phone"
+                            ]
+                        },
+                        {
+                            "canonicalForm": "text",
+                            "list": [
+                                "message",
+                                "text",
+                                "sms",
+                                "text message"
+                            ]
+                        },
+                        {
+                            "canonicalForm": "fax",
+                            "list": [
+                                "fax",
+                                "fascimile"
+                            ]
+                        }
+                    ],
+                    "roles": []
                 }
-              ],
-              "regex_entities": [],
-              "model_features": [],
-              "regex_features": [],
-              "utterances": [
+            ],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
                 {
-                  "text": "set phone call as my communication preference",
-                  "intent": "CommunicationPreference",
-                  "entities": []
+                    "text": "set phone call as my communication preference",
+                    "intent": "CommunicationPreference",
+                    "entities": []
                 },
                 {
-                  "text": "I prefer to receive text messages",
-                  "intent": "CommunicationPreference",
-                  "entities": []
+                    "text": "I prefer to receive text messages",
+                    "intent": "CommunicationPreference",
+                    "entities": []
                 },
                 {
-                  "text": "can you help",
-                  "intent": "Help",
-                  "entities": []
+                    "text": "can you help",
+                    "intent": "Help",
+                    "entities": []
                 }
-              ],
-              "patterns": [],
-              "patternAnyEntities": [],
-              "prebuiltEntities": [],
-            }
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
+        }
     },
     "1-intent": {
         "lufile":`# Greeting
@@ -382,42 +382,42 @@ module.exports.tests = {
         - Good morning
         - Good evening`,
         "luisJSON": {
-          "intents": [
-            {
-              "name": "Greeting"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "Hi",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Hello",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Good morning",
-              "intent": "Greeting",
-              "entities": []
-            },
-            {
-              "text": "Good evening",
-              "intent": "Greeting",
-              "entities": []
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            "intents": [
+                {
+                    "name": "Greeting"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "Hi",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Hello",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Good morning",
+                    "intent": "Greeting",
+                    "entities": []
+                },
+                {
+                    "text": "Good evening",
+                    "intent": "Greeting",
+                    "entities": []
+                }
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
     },
     "1-intent-prebuilt-entity":{
@@ -428,42 +428,42 @@ module.exports.tests = {
         - create an alarm for 7AM
         - set an alarm for 7AM next thursday`,
         "luisJSON":{
-          "intents": [
-            {
-              "name": "CreateAlarm"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "create an alarm",
-              "intent": "CreateAlarm",
-              "entities": []
-            },
-            {
-              "text": "create an alarm for 7AM",
-              "intent": "CreateAlarm",
-              "entities": []
-            },
-            {
-              "text": "set an alarm for 7AM next thursday",
-              "intent": "CreateAlarm",
-              "entities": []
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [
-            {
-              "name": "datetimeV2",
-              "roles": []
-            }
-          ],
+            "intents": [
+                {
+                    "name": "CreateAlarm"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "create an alarm",
+                    "intent": "CreateAlarm",
+                    "entities": []
+                },
+                {
+                    "text": "create an alarm for 7AM",
+                    "intent": "CreateAlarm",
+                    "entities": []
+                },
+                {
+                    "text": "set an alarm for 7AM next thursday",
+                    "intent": "CreateAlarm",
+                    "entities": []
+                }
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [
+                {
+                    "name": "datetimeV2",
+                    "roles": []
+                }
+            ],
         }
     },
     "1-intent-patern-prebuilt":{
@@ -475,38 +475,38 @@ module.exports.tests = {
         > alarmTime is a role for prebuilt datetimev2 entity
         $alarmTime:datetimeV2`,
         "luisJSON":{
-          "intents": [
-            {
-              "name": "DeleteAlarm"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "delete alarm",
-              "intent": "DeleteAlarm",
-              "entities": []
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [
-            {
-              "name": "datetimeV2",
-              "roles": []
-            },
-            {
-              "type": "datetimeV2",
-              "roles": [
-                "alarmTime"
-              ]
-            }
-          ],
+            "intents": [
+                {
+                    "name": "DeleteAlarm"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "delete alarm",
+                    "intent": "DeleteAlarm",
+                    "entities": []
+                }
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [
+                {
+                    "name": "datetimeV2",
+                    "roles": []
+                },
+                {
+                    "type": "datetimeV2",
+                    "roles": [
+                        "alarmTime"
+                    ]
+                }
+            ],
         }
     },
     "1-intent-pattern-patternAny": {
@@ -515,42 +515,42 @@ module.exports.tests = {
         - set {commPreference} as my communication preference
         - I prefer to receive {commPreference}`,
         "luisJSON":{
-          "intents": [
-            {
-              "name": "CommunicationPreference"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "set {commPreference} as my communication preference",
-              "intent": "CommunicationPreference",
-              "entities": []
-            }
-          ],
-          "patterns": [
-            {
-              "pattern": "set {commPreference} as my communication preference",
-              "intent": "CommunicationPreference"
-            },
-            {
-              "pattern": "I prefer to receive {commPreference}",
-              "intent": "CommunicationPreference"
-            }
-          ],
-          "patternAnyEntities": [
-            {
-              "name": "commPreference",
-              "explicitList": [],
-              "roles": []
-            }
-          ],
-          "prebuiltEntities": [],
+            "intents": [
+                {
+                    "name": "CommunicationPreference"
+                }
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "set {commPreference} as my communication preference",
+                    "intent": "CommunicationPreference",
+                    "entities": []
+                }
+            ],
+            "patterns": [
+                {
+                    "pattern": "set {commPreference} as my communication preference",
+                    "intent": "CommunicationPreference"
+                },
+                {
+                    "pattern": "I prefer to receive {commPreference}",
+                    "intent": "CommunicationPreference"
+                }
+            ],
+            "patternAnyEntities": [
+                {
+                    "name": "commPreference",
+                    "explicitList": [],
+                    "roles": []
+                }
+            ],
+            "prebuiltEntities": [],
         }
     },
     "1-intent-pattern-list": {
@@ -568,54 +568,54 @@ module.exports.tests = {
             - phone
         `,
         "luisJSON":{
-          "intents": [
-            {
-              "name": "CommunicationPreference"
-            }
-          ],
-          "entities": [],
-          "composites": [],
-          "closedLists": [
-            {
-              "name": "commPreference",
-              "subLists": [
+            "intents": [
                 {
-                  "canonicalForm": "call",
-                  "list": [
-                    "phone call",
-                    "give me a ring",
-                    "ring",
-                    "call",
-                    "cell phone",
-                    "phone"
-                  ]
+                    "name": "CommunicationPreference"
                 }
-              ],
-              "roles": []
-            }
-          ],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "set {commPreference} as my communication preference",
-              "intent": "CommunicationPreference",
-              "entities": []
-            }
-          ],
-          "patterns": [
-            {
-              "pattern": "set {commPreference} as my communication preference",
-              "intent": "CommunicationPreference"
-            },
-            {
-              "pattern": "I prefer to receive {commPreference}",
-              "intent": "CommunicationPreference"
-            }
-          ],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            ],
+            "entities": [],
+            "composites": [],
+            "closedLists": [
+                {
+                    "name": "commPreference",
+                    "subLists": [
+                        {
+                            "canonicalForm": "call",
+                            "list": [
+                                "phone call",
+                                "give me a ring",
+                                "ring",
+                                "call",
+                                "cell phone",
+                                "phone"
+                            ]
+                        }
+                    ],
+                    "roles": []
+                }
+            ],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
+                {
+                    "text": "set {commPreference} as my communication preference",
+                    "intent": "CommunicationPreference",
+                    "entities": []
+                }
+            ],
+            "patterns": [
+                {
+                    "pattern": "set {commPreference} as my communication preference",
+                    "intent": "CommunicationPreference"
+                },
+                {
+                    "pattern": "I prefer to receive {commPreference}",
+                    "intent": "CommunicationPreference"
+                }
+            ],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
     },
     "1-intent-labelled-utterances": {
@@ -627,93 +627,93 @@ module.exports.tests = {
         - {userName=vishwac} is my name
         - you can call me {userName=vishwac}`,
         "luisJSON": {
-          "intents": [
-            {
-              "name": "AskForUserName"
-            }
-          ],
-          "entities": [
-            {
-              "name": "userName",
-              "roles": []
-            }
-          ],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            "intents": [
                 {
-                  "entity": "userName",
-                  "startPos": 0,
-                  "endPos": 6
+                    "name": "AskForUserName"
                 }
-              ]
-            },
-            {
-              "text": "I'm vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            ],
+            "entities": [
                 {
-                  "entity": "userName",
-                  "startPos": 4,
-                  "endPos": 10
+                    "name": "userName",
+                    "roles": []
                 }
-              ]
-            },
-            {
-              "text": "call me vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            ],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
                 {
-                  "entity": "userName",
-                  "startPos": 8,
-                  "endPos": 14
-                }
-              ]
-            },
-            {
-              "text": "my name is vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 0,
+                            "endPos": 6
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 11,
-                  "endPos": 17
-                }
-              ]
-            },
-            {
-              "text": "vishwac is my name",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "I'm vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 4,
+                            "endPos": 10
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 0,
-                  "endPos": 6
-                }
-              ]
-            },
-            {
-              "text": "you can call me vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "call me vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 8,
+                            "endPos": 14
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 16,
-                  "endPos": 22
+                    "text": "my name is vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 11,
+                            "endPos": 17
+                        }
+                    ]
+                },
+                {
+                    "text": "vishwac is my name",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 0,
+                            "endPos": 6
+                        }
+                    ]
+                },
+                {
+                    "text": "you can call me vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 16,
+                            "endPos": 22
+                        }
+                    ]
                 }
-              ]
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
     },
     "1-intent-1-entity": {
@@ -727,93 +727,93 @@ module.exports.tests = {
         
         $userName:simple`,
         "luisJSON": {
-          "intents": [
-            {
-              "name": "AskForUserName"
-            }
-          ],
-          "entities": [
-            {
-              "name": "userName",
-              "roles": []
-            }
-          ],
-          "composites": [],
-          "closedLists": [],
-          "regex_entities": [],
-          "model_features": [],
-          "regex_features": [],
-          "utterances": [
-            {
-              "text": "vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            "intents": [
                 {
-                  "entity": "userName",
-                  "startPos": 0,
-                  "endPos": 6
+                    "name": "AskForUserName"
                 }
-              ]
-            },
-            {
-              "text": "I'm vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            ],
+            "entities": [
                 {
-                  "entity": "userName",
-                  "startPos": 4,
-                  "endPos": 10
+                    "name": "userName",
+                    "roles": []
                 }
-              ]
-            },
-            {
-              "text": "call me vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+            ],
+            "composites": [],
+            "closedLists": [],
+            "regex_entities": [],
+            "model_features": [],
+            "regex_features": [],
+            "utterances": [
                 {
-                  "entity": "userName",
-                  "startPos": 8,
-                  "endPos": 14
-                }
-              ]
-            },
-            {
-              "text": "my name is vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 0,
+                            "endPos": 6
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 11,
-                  "endPos": 17
-                }
-              ]
-            },
-            {
-              "text": "vishwac is my name",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "I'm vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 4,
+                            "endPos": 10
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 0,
-                  "endPos": 6
-                }
-              ]
-            },
-            {
-              "text": "you can call me vishwac",
-              "intent": "AskForUserName",
-              "entities": [
+                    "text": "call me vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 8,
+                            "endPos": 14
+                        }
+                    ]
+                },
                 {
-                  "entity": "userName",
-                  "startPos": 16,
-                  "endPos": 22
+                    "text": "my name is vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 11,
+                            "endPos": 17
+                        }
+                    ]
+                },
+                {
+                    "text": "vishwac is my name",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 0,
+                            "endPos": 6
+                        }
+                    ]
+                },
+                {
+                    "text": "you can call me vishwac",
+                    "intent": "AskForUserName",
+                    "entities": [
+                        {
+                            "entity": "userName",
+                            "startPos": 16,
+                            "endPos": 22
+                        }
+                    ]
                 }
-              ]
-            }
-          ],
-          "patterns": [],
-          "patternAnyEntities": [],
-          "prebuiltEntities": [],
+            ],
+            "patterns": [],
+            "patternAnyEntities": [],
+            "prebuiltEntities": [],
         }
     }
 };

--- a/packages/Ludown/test/testcases/translate-testcase-data.js
+++ b/packages/Ludown/test/testcases/translate-testcase-data.js
@@ -33,8 +33,8 @@ $commPreference:call=
 - call
 - cell phone
 - phone`,
-'langCode':'de',
-'translatedContent': `$userName:simple
+        'langCode':'de',
+        'translatedContent': `$userName:simple
 $PREBUILT:datetimeV2
 $PREBUILT:age
 $PREBUILT:dimension


### PR DESCRIPTION
## Proposed Changes
- Correct the mistakenly indentation of the case clause inside a switch statement.

## Testing
ESLint check should not warn about wrong indentation. In case ESLint rules severity is set to `error`, Travis build should not fail.