### PR TITLE
Fix no-unused-var warnings

### DIFF
--- a/packages/Chatdown/test/chatdown.cli.test.suite.js
+++ b/packages/Chatdown/test/chatdown.cli.test.suite.js
@@ -58,14 +58,14 @@ describe('The Chatdown cli tool', () => {
     });
 
     it('should process all files when a glob is passed in with the -f argument, and the -o is passed in for the output directory', done => {
-        exec(`node ${chatdown} -f **/*.chat -o ./`, (error, stdout, stderr) => {
+        exec(`node ${chatdown} -f **/*.chat -o ./`, (error, stdout) => {
             assert(stdout.includes('Successfully wrote'));
             done();
         });
     });
 
     it('should process all files when a glob is passed in with the -f argument', done => {
-        exec(`node ${chatdown} -f **/*.chat`, (error, stdout, stderr) => {
+        exec(`node ${chatdown} -f **/*.chat`, (error, stdout) => {
             assert(stdout.includes('Successfully wrote'));
             done();
         });

--- a/packages/Ludown/lib/toLU-helpers.js
+++ b/packages/Ludown/lib/toLU-helpers.js
@@ -4,7 +4,6 @@
  * Licensed under the MIT License.
  */
 const helperClasses = require('./classes/hclasses');
-const helpers = require('./helpers');
 const NEWLINE = require('os').EOL;
 const toLUHelpers = {
     /**

--- a/packages/Ludown/test/ludown.filereferences.test.suite.js
+++ b/packages/Ludown/test/ludown.filereferences.test.suite.js
@@ -14,12 +14,6 @@ const NEWLINE = require('os').EOL;
 const TEST_ROOT = path.join(__dirname);
 const PATH_TO_OUTPUT_FOLDER = path.resolve(TEST_ROOT + '/output');
 
-function compareFiles(actualPath, expectedPath) {
-    let expected = txtfile.readSync(actualPath).split(/\r?\n/);
-    let actual = txtfile.readSync(expectedPath).split(/\r?\n/);
-    assert.deepEqual(actual, expected);
-}
-
 function sanitizeExampleJson(fileContent) {
     let escapedExampleNewLine = JSON.stringify('\r\n').replace(/"/g, '').replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
     let escapedNewLine = JSON.stringify(NEWLINE).replace(/"/g, '');

--- a/packages/Ludown/test/ludown.qnafiles.test.suite.js
+++ b/packages/Ludown/test/ludown.qnafiles.test.suite.js
@@ -11,7 +11,7 @@ describe('With parse file function', function() {
     it('Throws when input lu file has invalid URIs', function(done){
         let fileContent = `[InvalidPDF](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN2.pdf)`;
         parseFile(fileContent, false, null)
-            .then(done('Test fail! did not throw when expected'))
+            .then(() => done('Test fail! did not throw when expected'))
             .catch(err => {
                 assert.equal(err.errCode, retCode.INVALID_URI);
                 done()

--- a/packages/Ludown/test/ludown.qnafiles.test.suite.js
+++ b/packages/Ludown/test/ludown.qnafiles.test.suite.js
@@ -11,7 +11,7 @@ describe('With parse file function', function() {
     it('Throws when input lu file has invalid URIs', function(done){
         let fileContent = `[InvalidPDF](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN2.pdf)`;
         parseFile(fileContent, false, null)
-            .then(res => done('Test fail! did not throw when expected'))
+            .then(done('Test fail! did not throw when expected'))
             .catch(err => {
                 assert.equal(err.errCode, retCode.INVALID_URI);
                 done()

--- a/packages/MSBot/test/msbot.connect.test.suite.js
+++ b/packages/MSBot/test/msbot.connect.test.suite.js
@@ -24,7 +24,7 @@ describe("msbot connection tests", () => {
         command += `-s 2f510b5e-10fe-4f53-9159-b134539ac594 `;
         command += `--tenantId microsoft.onmicrosoft.com `
         command += `--resourceGroup testGroup`;
-        let p = await exec(command);
+        await exec(command);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -48,7 +48,7 @@ describe("msbot connection tests", () => {
         bot.name = "test";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect blob -b save.bot -n TestBlob --serviceName testBlob --connectionString testConnection --container testContainer --secret ${secret} -s 2f510b5e-10fe-4f53-9159-b134539ac594 --tenantId microsoft.onmicrosoft.com --resourceGroup testGroup `);
+        await exec(`node ${msbot} connect blob -b save.bot -n TestBlob --serviceName testBlob --connectionString testConnection --container testContainer --secret ${secret} -s 2f510b5e-10fe-4f53-9159-b134539ac594 --tenantId microsoft.onmicrosoft.com --resourceGroup testGroup `);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -72,7 +72,7 @@ describe("msbot connection tests", () => {
         bot.description = "testd";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect bot -b save.bot -n TestBot --serviceName TestBot --secret ${secret} --endpoint http://foo.com/api/messages -s 2f510b5e-10fe-4f53-9159-b134539ac594 --appId 2f510b5e-10fe-4f53-9159-b134539ac594 --appPassword appPassword --tenantId microsoft.onmicrosoft.com --resourceGroup test `);
+        await exec(`node ${msbot} connect bot -b save.bot -n TestBot --serviceName TestBot --secret ${secret} --endpoint http://foo.com/api/messages -s 2f510b5e-10fe-4f53-9159-b134539ac594 --appId 2f510b5e-10fe-4f53-9159-b134539ac594 --appPassword appPassword --tenantId microsoft.onmicrosoft.com --resourceGroup test `);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -95,7 +95,7 @@ describe("msbot connection tests", () => {
         bot.name = "test";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect cosmosdb -b save.bot -n TestCosmos --serviceName testCosmos --endpoint http://localhost:8081 --key testKey --database testDatabase --collection testCollection --secret ${secret} -s 2f510b5e-10fe-4f53-9159-b134539ac594 --tenantId microsoft.onmicrosoft.com --resourceGroup testGroup `);
+        await exec(`node ${msbot} connect cosmosdb -b save.bot -n TestCosmos --serviceName testCosmos --endpoint http://localhost:8081 --key testKey --database testDatabase --collection testCollection --secret ${secret} -s 2f510b5e-10fe-4f53-9159-b134539ac594 --tenantId microsoft.onmicrosoft.com --resourceGroup testGroup `);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -154,7 +154,7 @@ describe("msbot connection tests", () => {
         bot.description = "testd";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect luis -b save.bot --secret ${secret} -n LUIS -a 2f510b5e-10fe-4f53-9159-b134539ac594 --authoringKey 2f510b5e-10fe-4f53-9159-b134539ac594 --subscriptionKey 2f510b5e-10fe-4f53-9159-b134539ac594 --region eastus --version 1.0`);
+        await exec(`node ${msbot} connect luis -b save.bot --secret ${secret} -n LUIS -a 2f510b5e-10fe-4f53-9159-b134539ac594 --authoringKey 2f510b5e-10fe-4f53-9159-b134539ac594 --subscriptionKey 2f510b5e-10fe-4f53-9159-b134539ac594 --region eastus --version 1.0`);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -176,7 +176,7 @@ describe("msbot connection tests", () => {
         bot.description = "testd";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect endpoint -b save.bot --secret ${secret} -n Endpoint2 --endpoint https://foo.com/api/messages --appId 2f510b5e-10fe-4f53-9159-b134539ac594 --appPassword appPassword`);
+        await exec(`node ${msbot} connect endpoint -b save.bot --secret ${secret} -n Endpoint2 --endpoint https://foo.com/api/messages --appId 2f510b5e-10fe-4f53-9159-b134539ac594 --appPassword appPassword`);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -201,7 +201,7 @@ describe("msbot connection tests", () => {
         command += `--url https://bing.com `;
         command += `--keys "{\\"key1\\":\\"value1\\"}" `;
         command += `--secret ${secret}`;
-        let p = await exec(command);
+        await exec(command);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -221,7 +221,7 @@ describe("msbot connection tests", () => {
         bot.description = "testd";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect qna -b save.bot --secret ${secret} -n QnA --hostname https://foo.com/qnamaker -k 2f510b5e-10fe-4f53-9159-b134539ac594 --subscriptionKey 2f510b5e-10fe-4f53-9159-b134539ac594 --endpointKey  2f510b5e-10fe-4f53-9159-b134539ac594 `);
+        await exec(`node ${msbot} connect qna -b save.bot --secret ${secret} -n QnA --hostname https://foo.com/qnamaker -k 2f510b5e-10fe-4f53-9159-b134539ac594 --subscriptionKey 2f510b5e-10fe-4f53-9159-b134539ac594 --endpointKey  2f510b5e-10fe-4f53-9159-b134539ac594 `);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");
@@ -240,7 +240,7 @@ describe("msbot connection tests", () => {
         bot.name = "test";
         await bot.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} connect file -b save.bot -f docs/readme.md --secret ${secret}  `);
+        await exec(`node ${msbot} connect file -b save.bot -f docs/readme.md --secret ${secret}  `);
 
         let config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");

--- a/packages/MSBot/test/msbot.disconnect.test.suite.js
+++ b/packages/MSBot/test/msbot.disconnect.test.suite.js
@@ -15,7 +15,7 @@ describe("msbot disconnect tests", () => {
         // save as save.bot
         await config.saveAs("save.bot", secret);
 
-        let p = await exec(`node ${msbot} disconnect -b save.bot --secret ${secret} testLuis`);
+        await exec(`node ${msbot} disconnect -b save.bot --secret ${secret} testLuis`);
         config = await bf.BotConfiguration.load("save.bot", secret);
         assert.equal(config.services.length, 8, "service wasn't removed");
 
@@ -30,7 +30,7 @@ describe("msbot disconnect tests", () => {
         await config.saveAs("save.bot", secret);
 
         let service = config.services[3];
-        let p = await exec(`node ${msbot} disconnect -b save.bot --secret ${secret} ${service.id}`);
+        await exec(`node ${msbot} disconnect -b save.bot --secret ${secret} ${service.id}`);
         config = await bf.BotConfiguration.load("save.bot", secret);
         assert.equal(config.services.length, 8, "service wasn't removed");
         assert.equal(null, config.findService(service.id), "service should have been removed");

--- a/packages/QnAMaker/test/qnamaker.cli.test.suite.js
+++ b/packages/QnAMaker/test/qnamaker.cli.test.suite.js
@@ -53,7 +53,7 @@ describe('The QnA Maker cli bin', () => {
 
         it('should update the key', function(done) {
             if (!subscriptionKey) this.skip('subscriptionKey not found');
-            exec(`node ${qnamaker} --subscriptionKey ${subscriptionKey} set`, (error, stdout, stderr) => {
+            exec(`node ${qnamaker} --subscriptionKey ${subscriptionKey} set`, (error, stdout) => {
                 let result = JSON.parse(stdout);
                 assert.equal(result.subscriptionKey, subscriptionKey, 'Key not found');
                 done();


### PR DESCRIPTION
## Proposed Changes
Remove unused variable and functions to fix `no-unused-var` ESLint warnings in BotBuilder Tools JS


## Testing
Travis will no longer report these warnings.