### PR TITLE
Fix no-undef and no-extra-semi warnings

### DIFF
--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -151,7 +151,7 @@ const parseFileContentsModule = {
             } else if(chunk.indexOf(PARSERCONSTS.QNA) === 0) {
                 parsedContent.qnaJsonStructure.qnaList.push(new qnaListObj(0, chunkSplitByLine[1], 'custom editorial', [chunkSplitByLine[0].replace(PARSERCONSTS.QNA, '').trim()], []));
             } 
-        };
+        }
         return parsedContent;
     },
     /**

--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -128,7 +128,7 @@ const parseFileContentsModule = {
         }
         // loop through every chunk of information
         for(let chunkIdx in splitOnBlankLines) {
-            chunk = splitOnBlankLines[chunkIdx];
+            const chunk = splitOnBlankLines[chunkIdx];
             let chunkSplitByLine = chunk.split(NEWLINE);
             if(chunk.indexOf(PARSERCONSTS.URLORFILEREF) === 0) {
                 try {

--- a/packages/MSBot/test/msbot.command.test.suite.js
+++ b/packages/MSBot/test/msbot.command.test.suite.js
@@ -74,7 +74,7 @@ describe("msbot commands", () => {
         config.saveAs('save.bot', secret);
 
         // test new secret
-        p = await exec(`node ${msbot} secret -b save.bot --secret ${secret} --new`);
+        const p = await exec(`node ${msbot} secret -b save.bot --secret ${secret} --new`);
         fs.unlinkSync("save.bot");
         let secret2 = p.stdout.split('\n')[1];
         assert.notEqual(secret2, secret, "secret should change");
@@ -86,7 +86,7 @@ describe("msbot commands", () => {
         config.saveAs('save.bot', secret);
 
         // test clear secret
-        p = await exec(`node ${msbot} secret -b save.bot --secret ${secret} --clear`);
+        await exec(`node ${msbot} secret -b save.bot --secret ${secret} --clear`);
 
         // verify we can load without a password
         config = await bf.BotConfiguration.load("save.bot");


### PR DESCRIPTION
## Proposed Changes
Fix `no-undef` and `no-extra-semi` warnings in BotBuilder Tools JS

## Testing
Travis will no longer report these warnings