### PR TITLE
Fix collision with entities that has 'simple' in their name

### DIFF
--- a/packages/Ludown/lib/helpers.js
+++ b/packages/Ludown/lib/helpers.js
@@ -176,7 +176,7 @@ const helpers = {
                         middleOfSection = true;
                         currentSectionType = PARSERCONSTS.ENTITY;
                         currentSection = currentLine + NEWLINE;
-                    } else if(LUISBuiltInTypes.includes(entityType.trim()) || entityType.trim().toLowerCase().includes('simple')) {
+                    } else if(LUISBuiltInTypes.includes(entityType.trim()) || entityType.trim().toLowerCase() === 'simple') {
                         // this is a built in type definition. Just add it.
                         sectionsInFile.push(currentLine);
                         middleOfSection = false;

--- a/packages/Ludown/test/ludown.helpers.test.suite.js
+++ b/packages/Ludown/test/ludown.helpers.test.suite.js
@@ -195,4 +195,15 @@ describe('With helper functions', function() {
             done();
         }
     });
+
+    it('splitFileBySections should accept entity definitions containing "simple" in their name', function(done){
+        let testLu = `$ServiceName:simple-service=
+        - Simple Test`;
+        try {
+            helpers.splitFileBySections(testLu, false);
+            done();
+        } catch (err) {
+            done(new Error('Test failed: splitFileBySections invalid entity definition!'));
+        }
+    });
 });


### PR DESCRIPTION
Running the command `ludown parse toluis` produces an error if the .lu file being parsed contains an entity with 'simple' on its name confusing it with the built-in 'Simple' entity type.
This change fixes the error `Error: Line #n is not part of a Intent/ Entity/ QnA` that gets thrown instead of getting the entity parsed correctly.

Before applying the fix, the mocha test added for this case fails
<img width="517" alt="screenshot_39" src="https://user-images.githubusercontent.com/2738891/45710936-8192c680-bb5e-11e8-82dd-f320c71714a5.png">

<img width="499" alt="screenshot_38" src="https://user-images.githubusercontent.com/2738891/45711238-4c3aa880-bb5f-11e8-9ff5-2cdbde253242.png">

The [line 179](https://github.com/southworkscom/botbuilder-tools/blob/5dd7f8894ab758f7344504c86f318d164dda6ede/packages/Ludown/lib/helpers.js#L179) is comparing if the entityType **contains** the word 'simple', giving a wrong comparison if the entity name is a compound name like 'simple-test'.

With the fix in place, the test now passes correctly
<img width="499" alt="screenshot_42" src="https://user-images.githubusercontent.com/2738891/45711496-1fd35c00-bb60-11e8-8b74-e4230d7f91d3.png">
