### PR TITLE
Change outdated command in examples README

### DIFF
--- a/packages/Ludown/examples/README.MD
+++ b/packages/Ludown/examples/README.MD
@@ -1,9 +1,15 @@
 This folder contains several different examples of .lu files. 
 
-## Usage
+## Usage to generate files for LUIS
 
 ```bash
-ludown ./Examples/all.lu
+ludown parse ToLuis --in ./all.lu -o ./
+```
+
+## Usage to generate files for QnA Maker
+
+```bash
+ludown parse ToQna --in ./qna1.lu -o ./
 ```
 
 ludown tool will output:


### PR DESCRIPTION
The proposed command example doesn't work anymore.
This is a correction with the new syntax and an example for both types of parse (ToLuis and ToQna)
The path now is relative to the current folder (Since the README it's in the same place as the examples).