### PR TITLE
Fix missing parameters in --help description for chatdown

### DIFF
--- a/packages/Chatdown/lib/help.js
+++ b/packages/Chatdown/lib/help.js
@@ -29,7 +29,7 @@ module.exports = function (output) {
         wordWrap: true
     });
     table.push([chalk.cyan.bold('[chat]'), '[chat] is the location of the chat file to parse. If omitted, piping is assumed and stdin will be used for input.']);
-    table.push([chalk.cyan.bold('-v, --version'), 'Show version']);
+    table.push([chalk.cyan.bold('-v, --version'), 'Show version.']);
     table.push([chalk.cyan.bold('-f, --folder'), 'Process the files found at the given directory.']);
     table.push([chalk.cyan.bold('-o, --outFolder'), 'Uses the directory as the output path.']);
     table.push([chalk.cyan.bold('--help'), 'Prints this help info to the console.']);

--- a/packages/Chatdown/lib/help.js
+++ b/packages/Chatdown/lib/help.js
@@ -11,6 +11,7 @@ module.exports = function (output) {
         output = process.stderr;
     output.write('\nChatdown cli tool used to parse chat dialogs (.chat file) into a mock transcript file\n\n© 2018 Microsoft Corporation\n\n');
     output.write(chalk.cyan.bold(`chatdown [chat] [--help] [--version] [--static]\n\n`));
+    output.write(chalk.cyan.bold(`chatdown [-f ./path/*.chat] [-o ./out/path/] [--help] [--version] [--static]\n\n`));
     let left = 20;
     let width = windowSize ? windowSize.width : 250;
     let right = width - left - 3; // 3 is for 3 vertical bar characters
@@ -28,8 +29,10 @@ module.exports = function (output) {
         wordWrap: true
     });
     table.push([chalk.cyan.bold('[chat]'), '[chat] is the location of the chat file to parse. If omitted, piping is assumed and stdin will be used for input.']);
-    table.push([chalk.cyan.bold('-v, --version'), 'show version']);
+    table.push([chalk.cyan.bold('-v, --version'), 'Show version']);
+    table.push([chalk.cyan.bold('-f, --folder'), 'Process the files found at the given directory.']);
+    table.push([chalk.cyan.bold('-o, --outFolder'), 'Uses the directory as the output path.']);
     table.push([chalk.cyan.bold('--help'), 'Prints this help info to the console.']);
-    table.push([chalk.cyan.bold('--static'), 'use static timestamps when generating timestamps on activities.']);
+    table.push([chalk.cyan.bold('--static'), 'Use static timestamps when generating timestamps on activities.']);
     output.write(table.toString()+'\n');
 };


### PR DESCRIPTION
Before the changes were made, this was the output of the `--help` parameter
<img width="600" alt="--help missing parameters" src="https://user-images.githubusercontent.com/2738891/45824959-7f984700-bcc7-11e8-9c4f-abdcc9fe0959.png">

According to the arguments that are currently being parsed by the tool the next parameters must be described by the `--help` parameter and they were missing
<img width="600" alt="Arguments being parsed" src="https://user-images.githubusercontent.com/2738891/45825047-b40c0300-bcc7-11e8-8cc7-f8659dcef824.png">

After the changes an example using both parameters has been added and some minor casing changes.
<img width="600" alt="screenshot_61" src="https://user-images.githubusercontent.com/2738891/45825201-1238e600-bcc8-11e8-8a67-0121c6bcbce8.png">

Note that the tool uses [minimist](https://github.com/substack/minimist) to parse the arguments for the command. This library converts camelCase commands into normalized output commands
Per example: `outFolder` gets parsed as `out_folder`