### PR TITLE
Add --prefix arg to enable prefix in LUIS

### DIFF
--- a/packages/LUIS/bin/help.js
+++ b/packages/LUIS/bin/help.js
@@ -108,6 +108,7 @@ let configSection = {
         [chalk.cyan.bold('--versionId'), 'Specifies the version id. Overrides the .luisrc value and the LUIS_VERSION_ID environment variable.'],
         [chalk.cyan.bold('--region'), 'Specifies the authoring region for all requests. [westus|westeurope|australiaeast] Overrides the .luisrc value and the LUIS_REGION environment variable.'],
         [chalk.cyan.bold('--stdin'), 'Pull in service keys from stdin in the format of that is the output of: msbot get service'],
+        [chalk.cyan.bold('--prefix'), 'Appends [luis-apis] prefix to all messages'],
     ]
 };
 

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -31,6 +31,7 @@ const txtfile = require('read-text-file');
 
 const help = require('./help');
 const Delay = require('await-delay');
+const intercept = require("intercept-stdout");
 
 let args;
 
@@ -54,6 +55,11 @@ async function runProgram() {
         args._.includes('help')) {
         return help(args, process.stdout);
     }
+    if (args.prefix) {
+        const unhook_intercept = intercept(function(txt) {
+            return `[${pkg.name}]\n${txt}`;
+        });
+    }
     if (args.version || args.v) {
         return process.stdout.write(require(path.join(__dirname, '../package.json')).version + "\n");
     }
@@ -70,6 +76,7 @@ async function runProgram() {
     const config = await composeConfig();
     let serviceIn = {};
     if (args.stdin) {
+        process.env.PREFIX = 'prefix';
         let json = await stdin();
         serviceIn = JSON.parse(json);
     }

--- a/packages/LUIS/package-lock.json
+++ b/packages/LUIS/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "luis-apis",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -541,6 +541,14 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "intercept-stdout": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
+      "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
+      "requires": {
+        "lodash.toarray": "^3.0.0"
+      }
+    },
     "is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -674,6 +682,51 @@
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.toarray": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
+      "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
     },
     "mime-db": {
       "version": "1.33.0",

--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -45,6 +45,7 @@
     "cli-table3": "^0.5.0",
     "fs-extra": "^5.0.0",
     "get-stdin": "^6.0.0",
+    "intercept-stdout": "^0.1.2",
     "minimist": "^1.2.0",
     "ms-rest-js": "^0.17.375",
     "node-fetch": "^2.0.0",

--- a/packages/LUIS/test/luis.cli.test.suite.js
+++ b/packages/LUIS/test/luis.cli.test.suite.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { exec } = require('child_process');
 const luis = require.resolve('../bin/luis');
+const pkg = require('../package.json');
 
 describe('The LUIS cli tool', () => {
 
@@ -10,6 +11,27 @@ describe('The LUIS cli tool', () => {
             exec(`node ${luis} luis list apps`, (error, stdout, stderr) => {
                 assert.equal(stdout, '');
                 assert(stderr.includes('luis list apps --skip <integer> --take <integer>'));
+                done();
+            });
+        });
+        
+        it('should not prefix [luis-apis] to stdout when --prefix is not passed as an argument', done => {
+            exec(`echo bot=LuliBot=joe | node ${luis} --prefix`, (error, stdout, stderr) => {
+                assert.notEqual(stdout.startsWith(`[${pkg.name}]`), `It should not show the tag '[${pkg.name}]' when not using the argument --prefix`);
+                done();
+            });
+        });
+        
+        it('should prefix [luis-apis] to stdout when --prefix is passed as an argument', done => {
+            exec(`node ${luis} --version --prefix`, (error, stdout, stderr) => {
+                assert(stdout.startsWith(`[${pkg.name}]`), `It should show the tag '[${pkg.name}]' when using the argument --prefix`);
+                done();
+            });
+        });
+    
+        it('should prefix [luis-apis] to stderr when --prefix is passed as an argument', done => {
+            exec(`echo bot=LuliBot=joe | node ${luis} --prefix`, (error, stdout, stderr) => {
+                assert(stderr.startsWith(`[${pkg.name}]`), `It should show the tag '[${pkg.name}]' when using the argument --prefix`);
                 done();
             });
         });
@@ -39,6 +61,6 @@ describe('The LUIS cli tool', () => {
                 });
             });
         });
-        
+
     });
 });


### PR DESCRIPTION
## Proposed Changes
- Add `--prefix` argument to enable prefix for messages in `LUIS`.

## Testing
- Test for no prefixing without `--prefix`
- Test for normal logging with `--prefix`
- Test for error logging with `--prefix`
