### PR TITLE
Replaced new Buffer() for Buffer.from()

### DIFF
--- a/packages/Chatdown/lib/index.js
+++ b/packages/Chatdown/lib/index.js
@@ -490,7 +490,7 @@ async function addAttachment(activity, arg) {
         // if it is not a card
         if (!isCard(contentType) && charset !== 'UTF-8') {
             // send as base64
-            contentUrl = `data:${contentType};base64,${new Buffer(content).toString('base64')}`;
+            contentUrl = `data:${contentType};base64,${Buffer.from(content).toString('base64')}`;
             content = undefined;
         } else {
             contentUrl = undefined;

--- a/packages/MSBot/test/msbot.command.test.suite.js
+++ b/packages/MSBot/test/msbot.command.test.suite.js
@@ -61,7 +61,7 @@ describe("msbot commands", () => {
         // test add secret
         let p = await exec(`node ${msbot} secret -b save.bot --new`);
         let secret = p.stdout.split('\n')[1];
-        let buf = new Buffer(secret, "base64");
+        let buf = Buffer.from(secret, "base64");
         assert.equal(buf.length, 32, "secret should be 32 bytes");
         config = await bf.BotConfiguration.load("save.bot", secret);
         fs.unlinkSync("save.bot");


### PR DESCRIPTION
The [Chatdown ](https://github.com/southworkscom/botbuilder-tools/blob/5729c3ad9b5a3c4dcb239feb5522c433378ce3ae/packages/Chatdown/lib/index.js#L493) tool and the [MSBot mocha test ](https://github.com/southworkscom/botbuilder-tools/blob/5729c3ad9b5a3c4dcb239feb5522c433378ce3ae/packages/MSBot/test/msbot.command.test.suite.js#L64) are using the `new Buffer()` to create Buffers.
From [Node.js v6.x](https://nodejs.org/docs/latest-v6.x/api/buffer.html) until now, the usage of the Buffer class constructor is deprecated and considered **unsafe**

> The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead. 
Quote from [Node.js Docs](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1)


This change would mean that users (and test run outside of the scope of the maintainers of the package) won't be polluted with  errors that themselves can't (or don't know how to) fix or would have to fix every time they update the tools.

The migration of the use of the `new Buffer()` constructor to `Buffer.from()` drops the support for the versions of Node.js ≤ **v4.4.x** and **v5.0.0** — **v5.9.x** but since the projects have the requirement of having Node.js version 8.5 or higher **this is not a problem**.

For MSBot this only affects the test
_(Note the `msbot secret --new add`)_
<img width="800" alt="MSBot test" src="https://user-images.githubusercontent.com/2738891/45889162-1df2de00-bd96-11e8-948b-75804d09d7b8.png">

For Chatdown this affects not only the test but every time an attachment is parsed to create a mock transcription
_(Note the `when the input chat contains an attachment`)_
<img width="800" alt="Chatdown" src="https://user-images.githubusercontent.com/2738891/45889163-1df2de00-bd96-11e8-8354-303ea12f672e.png">

## Proposed Changes
Migrate both Chatdown and MSBot use of the `new Buffer()` constructor to the proposed replacement with the `Buffer.from()` function.

## Testing
After replacing the deprecated constructor with the recommended replacement, now the deprecation warnings had disappeared thus the possible security and usability problems that the tools could encounter.
For Chatdown (Not only the tests but the internal usage too)
_(Note the `when the input chat contains an attachment`)_
<img width="800" alt="Chatdown" src="https://user-images.githubusercontent.com/2738891/45890342-2698e380-bd99-11e8-8a32-37cbe246e193.png">
For the MSBot test suite 
_(Note the `msbot secret --new add`)_
<img width="800" alt="MSBot" src="https://user-images.githubusercontent.com/2738891/45890345-2698e380-bd99-11e8-9f27-18b9ff988b49.png">

