### PR TITLE
Fix issue with 'clone' parameters names

### DIFF
--- a/AzureDevOpsPipelines/deployment/clone-with-publish/source/msbot-clone.js
+++ b/AzureDevOpsPipelines/deployment/clone-with-publish/source/msbot-clone.js
@@ -5,6 +5,7 @@ class msbotClone {
     constructor() {
         this.parametersClone = {
             'name': 'name',
+            'resource-group': 'resource-group',
             'proj-name': 'proj-name',
             'code-dir': 'code-dir',
             'location': 'location',
@@ -21,7 +22,7 @@ class msbotClone {
         var inputs = this.core.GetParameters(this.parametersClone);
         this.core.run(`msbot clone services ` +
             `--subscriptionId ${this.core.subscriptionID} ` +
-            ` ${inputs.replace('proj-name', 'proj-file')} ` +
+            ` ${inputs.replace('proj-name', 'proj-file').replace('resource-group', 'groupName')} ` +
             `--force ` +
             `--verbose`, this.core.getCWD('code-dir'));
     }

--- a/AzureDevOpsPipelines/deployment/clone-with-publish/source/msbot-clone.ts
+++ b/AzureDevOpsPipelines/deployment/clone-with-publish/source/msbot-clone.ts
@@ -4,6 +4,7 @@ export class msbotClone {
 
     private parametersClone = {
         'name': 'name',
+        'resource-group': 'resource-group',
         'proj-name': 'proj-name',
         'code-dir': 'code-dir',
         'location': 'location',
@@ -22,7 +23,7 @@ export class msbotClone {
         var inputs: string = this.core.GetParameters(this.parametersClone);        
         this.core.run(`msbot clone services ` +
             `--subscriptionId ${this.core.subscriptionID} ` +
-            ` ${inputs.replace('proj-name', 'proj-file')} ` +
+            ` ${inputs.replace('proj-name', 'proj-file').replace('resource-group','groupName')} ` +
             `--force ` +
             `--verbose`,
             this.core.getCWD('code-dir'));


### PR DESCRIPTION
## Proposed Changes
- `msbot clone services` uses some same parameters as `az bot publish` but with different name. Fix it by replacing the current name for the actual name.