### PR TITLE
[Task] Fix issue with 'null' resource group in messages

### DIFF
--- a/AzureDevOpsPipelines/deployment/clone-with-publish/source/index.js
+++ b/AzureDevOpsPipelines/deployment/clone-with-publish/source/index.js
@@ -9,8 +9,8 @@ function run() {
     const cores = new Core_1.core();
     const publish = new bot_publish_1.botPublish();
     const clone = new msbot_clone_1.msbotClone();
-    console.log(`Checking if ${tl.getInput('name')} already exist in ${tl.getInput('group')}`);
-    if (cores.ValidateBot(tl.getInput('name'), tl.getInput('group'))) {
+    console.log(`Checking if ${tl.getInput('name')} already exist in ${tl.getInput('resource-group')}`);
+    if (cores.ValidateBot(tl.getInput('name'), tl.getInput('resource-group'))) {
         console.log('It does, creating publish...');
         publish.botPublish();
     }

--- a/AzureDevOpsPipelines/deployment/clone-with-publish/source/index.ts
+++ b/AzureDevOpsPipelines/deployment/clone-with-publish/source/index.ts
@@ -10,8 +10,8 @@ function run(): void {
     const publish = new botPublish();
     const clone = new msbotClone();
     
-    console.log(`Checking if ${tl.getInput('name')} already exist in ${tl.getInput('group')}`);
-    if (cores.ValidateBot(tl.getInput('name'), tl.getInput('group'))) {
+    console.log(`Checking if ${tl.getInput('name')} already exist in ${tl.getInput('resource-group')}`);
+    if (cores.ValidateBot(tl.getInput('name'), tl.getInput('resource-group'))) {
         console.log('It does, creating publish...');
         publish.botPublish();
     } else {


### PR DESCRIPTION
## Proposed Changes
- The messages showing the specified `resource group` are using the wrong task input field. Make them use the right input field.