### PR TITLE
Add support for passing port as parameter

### DIFF
--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
@@ -20,6 +20,6 @@ namespace AzureReverseProxy
         /// </summary>
         public string ResourceGroupLocation { get; set; }
         public string TenantId { get; set; }
-        public int Port { get; set; }
+        public string Port { get; set; }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
@@ -12,6 +12,6 @@ namespace AzureReverseProxy
         string ResourceGroupName { get; set; }
         string SubscriptionId { get; set; }
         string TenantId { get; set; }
-        int Port { get; set; }
+        string Port { get; set; }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
@@ -14,6 +14,7 @@ namespace AzureReverseProxyCMD
         private static AzureReverseTool AZProxy;
         private static bool DeleteResource = false;
         private static bool Run = true;
+        private static string Port;
         static void Main(string[] args)
         {
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
@@ -25,12 +26,15 @@ namespace AzureReverseProxyCMD
                 AZProxy.CloseListener().GetAwaiter().GetResult();
             };
 
+            GetParams(args);
             MainAsync().Wait();
         }
 
         private static async Task MainAsync()
         {
             var config = GetConfiguration();
+            config.Port = Port;
+
             AZProxy = new AzureReverseTool(config);
 
             Console.WriteLine($"Check existence of '{ config.DeploymentName }' in '{ config.ResourceGroupName }' group...");
@@ -51,6 +55,21 @@ namespace AzureReverseProxyCMD
             while (Run)
             {
                 await Task.Delay(100);
+            }
+        }
+
+        private static void GetParams(string[] args)
+        {
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "-port":
+                        Port = args[i + 1];
+                        break;
+                    default:
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
## Proposed Changes
- Add support for override port number configuration by passing the `-port` parameter
- Change **Port** property of `Configuration` from int to string

## Testing
![ARP port param](https://user-images.githubusercontent.com/39467613/61640899-7e7fcf80-ac74-11e9-8298-b0b734968cff.gif)

